### PR TITLE
feat(Cloud Databases): Create and Delete Logical Replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Go client library to interact with the various [IBM Cloud Cloud Databases APIs](
   * [Go modules](#go-modules)
   * [`go get` command](#go-get-command)
 - [Using the SDK](#using-the-sdk)
+- [Running the Integration Tests](#running-the-integration-tests)
 - [Questions](#questions)
 - [Issues](#issues)
 - [Open source @ IBM](#open-source--ibm)
@@ -82,6 +83,21 @@ Be sure to use the appropriate package name from the service table above for the
 
 ## Using the SDK
 For general SDK usage information, please see [this link](https://github.com/IBM/ibm-cloud-sdk-common/blob/main/README.md)
+
+## Running the Integration Tests
+To run the integration tests run the `make test-int` command in the root directory. If you wish to run all the integration tests
+you can configure your `cloud_databases.env` file as seen below:
+
+```
+CLOUD_DATABASES_URL=<service base url> (e.g. https://api.eu-gb.databases.cloud.ibm.com/v5/ibm)
+CLOUD_DATABASES_AUTH_TYPE=iam
+CLOUD_DATABASES_APIKEY=<IAM apikey>
+CLOUD_DATABASES_AUTH_URL=<IAM token service base URL - omit this if using the production environment>
+CLOUD_DATABASES_DEPLOYMENT_ID=<ID of an example deployment>
+CLOUD_DATABASES_REPLICA_ID=<ID of an example replica>
+```
+
+Make sure your env file is in the root directory.
 
 ## Questions
 

--- a/clouddatabasesv5/cloud_databases_v5.go
+++ b/clouddatabasesv5/cloud_databases_v5.go
@@ -3464,7 +3464,7 @@ type CreateLogicalReplicationSlotOptions struct {
 	// Deployment ID.
 	ID *string `json:"id" validate:"required,ne="`
 
-	LogicalReplicationSlot *LogicalReplicationSlotLogicalReplicationSlot `json:"logical_replication_slot,omitempty"`
+	LogicalReplicationSlot *LogicalReplicationSlot `json:"logical_replication_slot,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3484,7 +3484,7 @@ func (_options *CreateLogicalReplicationSlotOptions) SetID(id string) *CreateLog
 }
 
 // SetLogicalReplicationSlot : Allow user to set LogicalReplicationSlot
-func (_options *CreateLogicalReplicationSlotOptions) SetLogicalReplicationSlot(logicalReplicationSlot *LogicalReplicationSlotLogicalReplicationSlot) *CreateLogicalReplicationSlotOptions {
+func (_options *CreateLogicalReplicationSlotOptions) SetLogicalReplicationSlot(logicalReplicationSlot *LogicalReplicationSlot) *CreateLogicalReplicationSlotOptions {
 	_options.LogicalReplicationSlot = logicalReplicationSlot
 	return _options
 }
@@ -3511,21 +3511,21 @@ func UnmarshalCreateLogicalReplicationSlotResponse(m map[string]json.RawMessage,
 	return
 }
 
-// LogicalReplicationSlotLogicalReplicationSlot : LogicalReplicationSlotLogicalReplicationSlot struct
-type LogicalReplicationSlotLogicalReplicationSlot struct {
+// LogicalReplicationSlot : LogicalReplicationSlot struct
+type LogicalReplicationSlot struct {
 	// name of the replication slot.
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name" validate:"required"`
 
 	// name of the database the replication slot is created on.
-	DatabaseName *string `json:"database_name,omitempty"`
+	DatabaseName *string `json:"database_name" validate:"required"`
 
 	// creating a replication slot is only supported for use with wal2json.
-	PluginType *string `json:"plugin_type,omitempty"`
+	PluginType *string `json:"plugin_type" validate:"required"`
 }
 
-// UnmarshalLogicalReplicationSlotLogicalReplicationSlot unmarshals an instance of LogicalReplicationSlotLogicalReplicationSlot from the specified map of raw messages.
-func UnmarshalLogicalReplicationSlotLogicalReplicationSlot(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(LogicalReplicationSlotLogicalReplicationSlot)
+// UnmarshalLogicalReplicationSlot unmarshals an instance of LogicalReplicationSlot from the specified map of raw messages.
+func UnmarshalLogicalReplicationSlot(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(LogicalReplicationSlot)
 	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
 	if err != nil {
 		return

--- a/clouddatabasesv5/cloud_databases_v5.go
+++ b/clouddatabasesv5/cloud_databases_v5.go
@@ -2042,6 +2042,10 @@ func UnmarshalAddAllowlistEntryResponse(m map[string]json.RawMessage, result int
 	return
 }
 
+type Allowlist struct {
+	AllowlistEntrys []AllowlistEntry `json:"ip_addresses"`
+}
+
 // AllowlistEntry : AllowlistEntry struct
 type AllowlistEntry struct {
 	// An IPv4 address or a CIDR range (netmasked IPv4 address).
@@ -2049,6 +2053,10 @@ type AllowlistEntry struct {
 
 	// A human readable description of the address or range for identification purposes.
 	Description *string `json:"description,omitempty"`
+}
+
+type AllowlistReq struct {
+	AllowlistEntry AllowlistEntry `json:"ip_address"`
 }
 
 // UnmarshalAllowlistEntry unmarshals an instance of AllowlistEntry from the specified map of raw messages.

--- a/clouddatabasesv5/cloud_databases_v5.go
+++ b/clouddatabasesv5/cloud_databases_v5.go
@@ -416,6 +416,77 @@ func (cloudDatabases *CloudDatabasesV5) CreateDatabaseUserWithContext(ctx contex
 	return
 }
 
+// CreateLogicalReplicationSlot : Create a new logical replication slot
+// Creates a new logical replication slot on the specified database. For use with PostgreSQL, EnterpriseDB, and wal2json
+// only.
+func (cloudDatabases *CloudDatabasesV5) CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions) (result *CreateLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
+	return cloudDatabases.CreateLogicalReplicationSlotWithContext(context.Background(), createLogicalReplicationSlotOptions)
+}
+
+// CreateLogicalReplicationSlotWithContext is an alternate form of the CreateLogicalReplicationSlot method which supports a Context parameter
+func (cloudDatabases *CloudDatabasesV5) CreateLogicalReplicationSlotWithContext(ctx context.Context, createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions) (result *CreateLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createLogicalReplicationSlotOptions, "createLogicalReplicationSlotOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createLogicalReplicationSlotOptions, "createLogicalReplicationSlotOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"id": *createLogicalReplicationSlotOptions.ID,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = cloudDatabases.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(cloudDatabases.Service.Options.URL, `/deployments/{id}/postgresql/logical_replication_slots`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createLogicalReplicationSlotOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("cloud_databases", "V5", "CreateLogicalReplicationSlot")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createLogicalReplicationSlotOptions.LogicalReplicationSlot != nil {
+		body["logical_replication_slot"] = createLogicalReplicationSlotOptions.LogicalReplicationSlot
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = cloudDatabases.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalCreateLogicalReplicationSlotResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
 // ChangeUserPassword : Set specified user's password
 // Sets the password of a specified user.
 func (cloudDatabases *CloudDatabasesV5) ChangeUserPassword(changeUserPasswordOptions *ChangeUserPasswordOptions) (result *ChangeUserPasswordResponse, response *core.DetailedResponse, err error) {
@@ -3320,6 +3391,89 @@ type CreateDatabaseUserResponse struct {
 func UnmarshalCreateDatabaseUserResponse(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(CreateDatabaseUserResponse)
 	err = core.UnmarshalModel(m, "task", &obj.Task, UnmarshalTask)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// CreateLogicalReplicationSlotOptions : The CreateLogicalReplicationSlot options.
+type CreateLogicalReplicationSlotOptions struct {
+	// Deployment ID.
+	ID *string `json:"id" validate:"required,ne="`
+
+	LogicalReplicationSlot *LogicalReplicationSlotLogicalReplicationSlot `json:"logical_replication_slot,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewCreateLogicalReplicationSlotOptions : Instantiate CreateLogicalReplicationSlotOptions
+func (*CloudDatabasesV5) NewCreateLogicalReplicationSlotOptions(id string) *CreateLogicalReplicationSlotOptions {
+	return &CreateLogicalReplicationSlotOptions{
+		ID: core.StringPtr(id),
+	}
+}
+
+// SetID : Allow user to set ID
+func (_options *CreateLogicalReplicationSlotOptions) SetID(id string) *CreateLogicalReplicationSlotOptions {
+	_options.ID = core.StringPtr(id)
+	return _options
+}
+
+// SetLogicalReplicationSlot : Allow user to set LogicalReplicationSlot
+func (_options *CreateLogicalReplicationSlotOptions) SetLogicalReplicationSlot(logicalReplicationSlot *LogicalReplicationSlotLogicalReplicationSlot) *CreateLogicalReplicationSlotOptions {
+	_options.LogicalReplicationSlot = logicalReplicationSlot
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateLogicalReplicationSlotOptions) SetHeaders(param map[string]string) *CreateLogicalReplicationSlotOptions {
+	options.Headers = param
+	return options
+}
+
+// CreateLogicalReplicationSlotResponse : CreateLogicalReplicationSlotResponse struct
+type CreateLogicalReplicationSlotResponse struct {
+	Task *Task `json:"task,omitempty"`
+}
+
+// UnmarshalCreateLogicalReplicationSlotResponse unmarshals an instance of CreateLogicalReplicationSlotResponse from the specified map of raw messages.
+func UnmarshalCreateLogicalReplicationSlotResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(CreateLogicalReplicationSlotResponse)
+	err = core.UnmarshalModel(m, "task", &obj.Task, UnmarshalTask)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// LogicalReplicationSlotLogicalReplicationSlot : LogicalReplicationSlotLogicalReplicationSlot struct
+type LogicalReplicationSlotLogicalReplicationSlot struct {
+	// name of the replication slot.
+	Name *string `json:"name,omitempty"`
+
+	// name of the database the replication slot is created on.
+	DatabaseName *string `json:"database_name,omitempty"`
+
+	// creating a replication slot is only supported for use with wal2json.
+	PluginType *string `json:"plugin_type,omitempty"`
+}
+
+// UnmarshalLogicalReplicationSlotLogicalReplicationSlot unmarshals an instance of LogicalReplicationSlotLogicalReplicationSlot from the specified map of raw messages.
+func UnmarshalLogicalReplicationSlotLogicalReplicationSlot(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(LogicalReplicationSlotLogicalReplicationSlot)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "database_name", &obj.DatabaseName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "plugin_type", &obj.PluginType)
 	if err != nil {
 		return
 	}

--- a/clouddatabasesv5/cloud_databases_v5.go
+++ b/clouddatabasesv5/cloud_databases_v5.go
@@ -487,6 +487,67 @@ func (cloudDatabases *CloudDatabasesV5) CreateLogicalReplicationSlotWithContext(
 	return
 }
 
+// DeleteLogicalReplicationSlot : Delete a logical replication slot
+// Deletes a logical replication slot from a database. For use with PostgreSQL, EnterpriseDB, and wal2json only.
+func (cloudDatabases *CloudDatabasesV5) DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions) (result *DeleteLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
+	return cloudDatabases.DeleteLogicalReplicationSlotWithContext(context.Background(), deleteLogicalReplicationSlotOptions)
+}
+
+// DeleteLogicalReplicationSlotWithContext is an alternate form of the DeleteLogicalReplicationSlot method which supports a Context parameter
+func (cloudDatabases *CloudDatabasesV5) DeleteLogicalReplicationSlotWithContext(ctx context.Context, deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions) (result *DeleteLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteLogicalReplicationSlotOptions, "deleteLogicalReplicationSlotOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(deleteLogicalReplicationSlotOptions, "deleteLogicalReplicationSlotOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"id":   *deleteLogicalReplicationSlotOptions.ID,
+		"name": *deleteLogicalReplicationSlotOptions.Name,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = cloudDatabases.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(cloudDatabases.Service.Options.URL, `/deployments/{id}/postgresql/logical_replication_slots/{name}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range deleteLogicalReplicationSlotOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("cloud_databases", "V5", "DeleteLogicalReplicationSlot")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = cloudDatabases.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalDeleteLogicalReplicationSlotResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
 // ChangeUserPassword : Set specified user's password
 // Sets the password of a specified user.
 func (cloudDatabases *CloudDatabasesV5) ChangeUserPassword(changeUserPasswordOptions *ChangeUserPasswordOptions) (result *ChangeUserPasswordResponse, response *core.DetailedResponse, err error) {
@@ -3474,6 +3535,60 @@ func UnmarshalLogicalReplicationSlotLogicalReplicationSlot(m map[string]json.Raw
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "plugin_type", &obj.PluginType)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// DeleteLogicalReplicationSlotOptions : The DeleteLogicalReplicationSlot options.
+type DeleteLogicalReplicationSlotOptions struct {
+	// Deployment ID.
+	ID *string `json:"id" validate:"required,ne="`
+
+	// Name of the logical replication slot.
+	Name *string `json:"name" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDeleteLogicalReplicationSlotOptions : Instantiate DeleteLogicalReplicationSlotOptions
+func (*CloudDatabasesV5) NewDeleteLogicalReplicationSlotOptions(id string, name string) *DeleteLogicalReplicationSlotOptions {
+	return &DeleteLogicalReplicationSlotOptions{
+		ID:   core.StringPtr(id),
+		Name: core.StringPtr(name),
+	}
+}
+
+// SetID : Allow user to set ID
+func (_options *DeleteLogicalReplicationSlotOptions) SetID(id string) *DeleteLogicalReplicationSlotOptions {
+	_options.ID = core.StringPtr(id)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *DeleteLogicalReplicationSlotOptions) SetName(name string) *DeleteLogicalReplicationSlotOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteLogicalReplicationSlotOptions) SetHeaders(param map[string]string) *DeleteLogicalReplicationSlotOptions {
+	options.Headers = param
+	return options
+}
+
+// DeleteLogicalReplicationSlotResponse : DeleteLogicalReplicationSlotResponse struct
+type DeleteLogicalReplicationSlotResponse struct {
+	Task *Task `json:"task,omitempty"`
+}
+
+// UnmarshalDeleteLogicalReplicationSlotResponse unmarshals an instance of DeleteLogicalReplicationSlotResponse from the specified map of raw messages.
+func UnmarshalDeleteLogicalReplicationSlotResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(DeleteLogicalReplicationSlotResponse)
+	err = core.UnmarshalModel(m, "task", &obj.Task, UnmarshalTask)
 	if err != nil {
 		return
 	}

--- a/clouddatabasesv5/cloud_databases_v5.go
+++ b/clouddatabasesv5/cloud_databases_v5.go
@@ -2174,10 +2174,6 @@ func UnmarshalAddAllowlistEntryResponse(m map[string]json.RawMessage, result int
 	return
 }
 
-type Allowlist struct {
-	AllowlistEntrys []AllowlistEntry `json:"ip_addresses"`
-}
-
 // AllowlistEntry : AllowlistEntry struct
 type AllowlistEntry struct {
 	// An IPv4 address or a CIDR range (netmasked IPv4 address).
@@ -2185,10 +2181,6 @@ type AllowlistEntry struct {
 
 	// A human readable description of the address or range for identification purposes.
 	Description *string `json:"description,omitempty"`
-}
-
-type AllowlistReq struct {
-	AllowlistEntry AllowlistEntry `json:"ip_address"`
 }
 
 // UnmarshalAllowlistEntry unmarshals an instance of AllowlistEntry from the specified map of raw messages.

--- a/clouddatabasesv5/cloud_databases_v5.go
+++ b/clouddatabasesv5/cloud_databases_v5.go
@@ -1750,14 +1750,8 @@ func (cloudDatabases *CloudDatabasesV5) CreateLogicalReplicationSlotWithContext(
 	builder.AddHeader("Content-Type", "application/json")
 
 	body := make(map[string]interface{})
-	if createLogicalReplicationSlotOptions.Name != nil {
-		body["name"] = createLogicalReplicationSlotOptions.Name
-	}
-	if createLogicalReplicationSlotOptions.DatabaseName != nil {
-		body["database_name"] = createLogicalReplicationSlotOptions.DatabaseName
-	}
-	if createLogicalReplicationSlotOptions.PluginType != nil {
-		body["plugin_type"] = createLogicalReplicationSlotOptions.PluginType
+	if createLogicalReplicationSlotOptions.LogicalReplicationSlot != nil {
+		body["logical_replication_slot"] = createLogicalReplicationSlotOptions.LogicalReplicationSlot
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
@@ -3462,26 +3456,16 @@ type CreateLogicalReplicationSlotOptions struct {
 	// Deployment ID.
 	ID *string `json:"id" validate:"required,ne="`
 
-	// name of the replication slot.
-	Name *string `json:"name" validate:"required"`
-
-	// name of the database the replication slot is created on.
-	DatabaseName *string `json:"database_name" validate:"required"`
-
-	// creating a replication slot is only supported for use with wal2json.
-	PluginType *string `json:"plugin_type" validate:"required"`
+	LogicalReplicationSlot *LogicalReplicationSlot `json:"logical_replication_slot,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewCreateLogicalReplicationSlotOptions : Instantiate CreateLogicalReplicationSlotOptions
-func (*CloudDatabasesV5) NewCreateLogicalReplicationSlotOptions(id string, name string, databaseName string, pluginType string) *CreateLogicalReplicationSlotOptions {
+func (*CloudDatabasesV5) NewCreateLogicalReplicationSlotOptions(id string) *CreateLogicalReplicationSlotOptions {
 	return &CreateLogicalReplicationSlotOptions{
-		ID:           core.StringPtr(id),
-		Name:         core.StringPtr(name),
-		DatabaseName: core.StringPtr(databaseName),
-		PluginType:   core.StringPtr(pluginType),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -3491,21 +3475,9 @@ func (_options *CreateLogicalReplicationSlotOptions) SetID(id string) *CreateLog
 	return _options
 }
 
-// SetName : Allow user to set Name
-func (_options *CreateLogicalReplicationSlotOptions) SetName(name string) *CreateLogicalReplicationSlotOptions {
-	_options.Name = core.StringPtr(name)
-	return _options
-}
-
-// SetDatabaseName : Allow user to set DatabaseName
-func (_options *CreateLogicalReplicationSlotOptions) SetDatabaseName(databaseName string) *CreateLogicalReplicationSlotOptions {
-	_options.DatabaseName = core.StringPtr(databaseName)
-	return _options
-}
-
-// SetPluginType : Allow user to set PluginType
-func (_options *CreateLogicalReplicationSlotOptions) SetPluginType(pluginType string) *CreateLogicalReplicationSlotOptions {
-	_options.PluginType = core.StringPtr(pluginType)
+// SetLogicalReplicationSlot : Allow user to set LogicalReplicationSlot
+func (_options *CreateLogicalReplicationSlotOptions) SetLogicalReplicationSlot(logicalReplicationSlot *LogicalReplicationSlot) *CreateLogicalReplicationSlotOptions {
+	_options.LogicalReplicationSlot = logicalReplicationSlot
 	return _options
 }
 
@@ -4980,6 +4952,48 @@ type ListRemotesResponse struct {
 func UnmarshalListRemotesResponse(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(ListRemotesResponse)
 	err = core.UnmarshalModel(m, "remotes", &obj.Remotes, UnmarshalRemotes)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// LogicalReplicationSlot : LogicalReplicationSlot struct
+type LogicalReplicationSlot struct {
+	// name of the replication slot.
+	Name *string `json:"name" validate:"required"`
+
+	// name of the database the replication slot is created on.
+	DatabaseName *string `json:"database_name" validate:"required"`
+
+	// creating a replication slot is only supported for use with wal2json.
+	PluginType *string `json:"plugin_type" validate:"required"`
+}
+
+// NewLogicalReplicationSlot : Instantiate LogicalReplicationSlot (Generic Model Constructor)
+func (*CloudDatabasesV5) NewLogicalReplicationSlot(name string, databaseName string, pluginType string) (_model *LogicalReplicationSlot, err error) {
+	_model = &LogicalReplicationSlot{
+		Name:         core.StringPtr(name),
+		DatabaseName: core.StringPtr(databaseName),
+		PluginType:   core.StringPtr(pluginType),
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalLogicalReplicationSlot unmarshals an instance of LogicalReplicationSlot from the specified map of raw messages.
+func UnmarshalLogicalReplicationSlot(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(LogicalReplicationSlot)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "database_name", &obj.DatabaseName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "plugin_type", &obj.PluginType)
 	if err != nil {
 		return
 	}

--- a/clouddatabasesv5/cloud_databases_v5.go
+++ b/clouddatabasesv5/cloud_databases_v5.go
@@ -416,138 +416,6 @@ func (cloudDatabases *CloudDatabasesV5) CreateDatabaseUserWithContext(ctx contex
 	return
 }
 
-// CreateLogicalReplicationSlot : Create a new logical replication slot
-// Creates a new logical replication slot on the specified database. For use with PostgreSQL, EnterpriseDB, and wal2json
-// only.
-func (cloudDatabases *CloudDatabasesV5) CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions) (result *CreateLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
-	return cloudDatabases.CreateLogicalReplicationSlotWithContext(context.Background(), createLogicalReplicationSlotOptions)
-}
-
-// CreateLogicalReplicationSlotWithContext is an alternate form of the CreateLogicalReplicationSlot method which supports a Context parameter
-func (cloudDatabases *CloudDatabasesV5) CreateLogicalReplicationSlotWithContext(ctx context.Context, createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions) (result *CreateLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
-	err = core.ValidateNotNil(createLogicalReplicationSlotOptions, "createLogicalReplicationSlotOptions cannot be nil")
-	if err != nil {
-		return
-	}
-	err = core.ValidateStruct(createLogicalReplicationSlotOptions, "createLogicalReplicationSlotOptions")
-	if err != nil {
-		return
-	}
-
-	pathParamsMap := map[string]string{
-		"id": *createLogicalReplicationSlotOptions.ID,
-	}
-
-	builder := core.NewRequestBuilder(core.POST)
-	builder = builder.WithContext(ctx)
-	builder.EnableGzipCompression = cloudDatabases.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(cloudDatabases.Service.Options.URL, `/deployments/{id}/postgresql/logical_replication_slots`, pathParamsMap)
-	if err != nil {
-		return
-	}
-
-	for headerName, headerValue := range createLogicalReplicationSlotOptions.Headers {
-		builder.AddHeader(headerName, headerValue)
-	}
-
-	sdkHeaders := common.GetSdkHeaders("cloud_databases", "V5", "CreateLogicalReplicationSlot")
-	for headerName, headerValue := range sdkHeaders {
-		builder.AddHeader(headerName, headerValue)
-	}
-	builder.AddHeader("Accept", "application/json")
-	builder.AddHeader("Content-Type", "application/json")
-
-	body := make(map[string]interface{})
-	if createLogicalReplicationSlotOptions.LogicalReplicationSlot != nil {
-		body["logical_replication_slot"] = createLogicalReplicationSlotOptions.LogicalReplicationSlot
-	}
-	_, err = builder.SetBodyContentJSON(body)
-	if err != nil {
-		return
-	}
-
-	request, err := builder.Build()
-	if err != nil {
-		return
-	}
-
-	var rawResponse map[string]json.RawMessage
-	response, err = cloudDatabases.Service.Request(request, &rawResponse)
-	if err != nil {
-		return
-	}
-	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalCreateLogicalReplicationSlotResponse)
-		if err != nil {
-			return
-		}
-		response.Result = result
-	}
-
-	return
-}
-
-// DeleteLogicalReplicationSlot : Delete a logical replication slot
-// Deletes a logical replication slot from a database. For use with PostgreSQL, EnterpriseDB, and wal2json only.
-func (cloudDatabases *CloudDatabasesV5) DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions) (result *DeleteLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
-	return cloudDatabases.DeleteLogicalReplicationSlotWithContext(context.Background(), deleteLogicalReplicationSlotOptions)
-}
-
-// DeleteLogicalReplicationSlotWithContext is an alternate form of the DeleteLogicalReplicationSlot method which supports a Context parameter
-func (cloudDatabases *CloudDatabasesV5) DeleteLogicalReplicationSlotWithContext(ctx context.Context, deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions) (result *DeleteLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
-	err = core.ValidateNotNil(deleteLogicalReplicationSlotOptions, "deleteLogicalReplicationSlotOptions cannot be nil")
-	if err != nil {
-		return
-	}
-	err = core.ValidateStruct(deleteLogicalReplicationSlotOptions, "deleteLogicalReplicationSlotOptions")
-	if err != nil {
-		return
-	}
-
-	pathParamsMap := map[string]string{
-		"id":   *deleteLogicalReplicationSlotOptions.ID,
-		"name": *deleteLogicalReplicationSlotOptions.Name,
-	}
-
-	builder := core.NewRequestBuilder(core.DELETE)
-	builder = builder.WithContext(ctx)
-	builder.EnableGzipCompression = cloudDatabases.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(cloudDatabases.Service.Options.URL, `/deployments/{id}/postgresql/logical_replication_slots/{name}`, pathParamsMap)
-	if err != nil {
-		return
-	}
-
-	for headerName, headerValue := range deleteLogicalReplicationSlotOptions.Headers {
-		builder.AddHeader(headerName, headerValue)
-	}
-
-	sdkHeaders := common.GetSdkHeaders("cloud_databases", "V5", "DeleteLogicalReplicationSlot")
-	for headerName, headerValue := range sdkHeaders {
-		builder.AddHeader(headerName, headerValue)
-	}
-	builder.AddHeader("Accept", "application/json")
-
-	request, err := builder.Build()
-	if err != nil {
-		return
-	}
-
-	var rawResponse map[string]json.RawMessage
-	response, err = cloudDatabases.Service.Request(request, &rawResponse)
-	if err != nil {
-		return
-	}
-	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalDeleteLogicalReplicationSlotResponse)
-		if err != nil {
-			return
-		}
-		response.Result = result
-	}
-
-	return
-}
-
 // ChangeUserPassword : Set specified user's password
 // Sets the password of a specified user.
 func (cloudDatabases *CloudDatabasesV5) ChangeUserPassword(changeUserPasswordOptions *ChangeUserPasswordOptions) (result *ChangeUserPasswordResponse, response *core.DetailedResponse, err error) {
@@ -1831,6 +1699,144 @@ func (cloudDatabases *CloudDatabasesV5) KillConnectionsWithContext(ctx context.C
 	}
 	if rawResponse != nil {
 		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalKillConnectionsResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// CreateLogicalReplicationSlot : Create a new logical replication slot
+// Creates a new logical replication slot on the specified database. For use with PostgreSQL, EnterpriseDB, and wal2json
+// only.
+func (cloudDatabases *CloudDatabasesV5) CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions) (result *CreateLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
+	return cloudDatabases.CreateLogicalReplicationSlotWithContext(context.Background(), createLogicalReplicationSlotOptions)
+}
+
+// CreateLogicalReplicationSlotWithContext is an alternate form of the CreateLogicalReplicationSlot method which supports a Context parameter
+func (cloudDatabases *CloudDatabasesV5) CreateLogicalReplicationSlotWithContext(ctx context.Context, createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions) (result *CreateLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createLogicalReplicationSlotOptions, "createLogicalReplicationSlotOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createLogicalReplicationSlotOptions, "createLogicalReplicationSlotOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"id": *createLogicalReplicationSlotOptions.ID,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = cloudDatabases.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(cloudDatabases.Service.Options.URL, `/deployments/{id}/postgresql/logical_replication_slots`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createLogicalReplicationSlotOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("cloud_databases", "V5", "CreateLogicalReplicationSlot")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createLogicalReplicationSlotOptions.Name != nil {
+		body["name"] = createLogicalReplicationSlotOptions.Name
+	}
+	if createLogicalReplicationSlotOptions.DatabaseName != nil {
+		body["database_name"] = createLogicalReplicationSlotOptions.DatabaseName
+	}
+	if createLogicalReplicationSlotOptions.PluginType != nil {
+		body["plugin_type"] = createLogicalReplicationSlotOptions.PluginType
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = cloudDatabases.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalCreateLogicalReplicationSlotResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// DeleteLogicalReplicationSlot : Delete a logical replication slot
+// Deletes a logical replication slot from a database. For use with PostgreSQL, EnterpriseDB, and wal2json only.
+func (cloudDatabases *CloudDatabasesV5) DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions) (result *DeleteLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
+	return cloudDatabases.DeleteLogicalReplicationSlotWithContext(context.Background(), deleteLogicalReplicationSlotOptions)
+}
+
+// DeleteLogicalReplicationSlotWithContext is an alternate form of the DeleteLogicalReplicationSlot method which supports a Context parameter
+func (cloudDatabases *CloudDatabasesV5) DeleteLogicalReplicationSlotWithContext(ctx context.Context, deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions) (result *DeleteLogicalReplicationSlotResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteLogicalReplicationSlotOptions, "deleteLogicalReplicationSlotOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(deleteLogicalReplicationSlotOptions, "deleteLogicalReplicationSlotOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"id":   *deleteLogicalReplicationSlotOptions.ID,
+		"name": *deleteLogicalReplicationSlotOptions.Name,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = cloudDatabases.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(cloudDatabases.Service.Options.URL, `/deployments/{id}/postgresql/logical_replication_slots/{name}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range deleteLogicalReplicationSlotOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("cloud_databases", "V5", "DeleteLogicalReplicationSlot")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = cloudDatabases.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalDeleteLogicalReplicationSlotResponse)
 		if err != nil {
 			return
 		}
@@ -3456,16 +3462,26 @@ type CreateLogicalReplicationSlotOptions struct {
 	// Deployment ID.
 	ID *string `json:"id" validate:"required,ne="`
 
-	LogicalReplicationSlot *LogicalReplicationSlot `json:"logical_replication_slot,omitempty"`
+	// name of the replication slot.
+	Name *string `json:"name" validate:"required"`
+
+	// name of the database the replication slot is created on.
+	DatabaseName *string `json:"database_name" validate:"required"`
+
+	// creating a replication slot is only supported for use with wal2json.
+	PluginType *string `json:"plugin_type" validate:"required"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewCreateLogicalReplicationSlotOptions : Instantiate CreateLogicalReplicationSlotOptions
-func (*CloudDatabasesV5) NewCreateLogicalReplicationSlotOptions(id string) *CreateLogicalReplicationSlotOptions {
+func (*CloudDatabasesV5) NewCreateLogicalReplicationSlotOptions(id string, name string, databaseName string, pluginType string) *CreateLogicalReplicationSlotOptions {
 	return &CreateLogicalReplicationSlotOptions{
-		ID: core.StringPtr(id),
+		ID:           core.StringPtr(id),
+		Name:         core.StringPtr(name),
+		DatabaseName: core.StringPtr(databaseName),
+		PluginType:   core.StringPtr(pluginType),
 	}
 }
 
@@ -3475,9 +3491,21 @@ func (_options *CreateLogicalReplicationSlotOptions) SetID(id string) *CreateLog
 	return _options
 }
 
-// SetLogicalReplicationSlot : Allow user to set LogicalReplicationSlot
-func (_options *CreateLogicalReplicationSlotOptions) SetLogicalReplicationSlot(logicalReplicationSlot *LogicalReplicationSlot) *CreateLogicalReplicationSlotOptions {
-	_options.LogicalReplicationSlot = logicalReplicationSlot
+// SetName : Allow user to set Name
+func (_options *CreateLogicalReplicationSlotOptions) SetName(name string) *CreateLogicalReplicationSlotOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetDatabaseName : Allow user to set DatabaseName
+func (_options *CreateLogicalReplicationSlotOptions) SetDatabaseName(databaseName string) *CreateLogicalReplicationSlotOptions {
+	_options.DatabaseName = core.StringPtr(databaseName)
+	return _options
+}
+
+// SetPluginType : Allow user to set PluginType
+func (_options *CreateLogicalReplicationSlotOptions) SetPluginType(pluginType string) *CreateLogicalReplicationSlotOptions {
+	_options.PluginType = core.StringPtr(pluginType)
 	return _options
 }
 
@@ -3495,91 +3523,6 @@ type CreateLogicalReplicationSlotResponse struct {
 // UnmarshalCreateLogicalReplicationSlotResponse unmarshals an instance of CreateLogicalReplicationSlotResponse from the specified map of raw messages.
 func UnmarshalCreateLogicalReplicationSlotResponse(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(CreateLogicalReplicationSlotResponse)
-	err = core.UnmarshalModel(m, "task", &obj.Task, UnmarshalTask)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// LogicalReplicationSlot : LogicalReplicationSlot struct
-type LogicalReplicationSlot struct {
-	// name of the replication slot.
-	Name *string `json:"name" validate:"required"`
-
-	// name of the database the replication slot is created on.
-	DatabaseName *string `json:"database_name" validate:"required"`
-
-	// creating a replication slot is only supported for use with wal2json.
-	PluginType *string `json:"plugin_type" validate:"required"`
-}
-
-// UnmarshalLogicalReplicationSlot unmarshals an instance of LogicalReplicationSlot from the specified map of raw messages.
-func UnmarshalLogicalReplicationSlot(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(LogicalReplicationSlot)
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "database_name", &obj.DatabaseName)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "plugin_type", &obj.PluginType)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// DeleteLogicalReplicationSlotOptions : The DeleteLogicalReplicationSlot options.
-type DeleteLogicalReplicationSlotOptions struct {
-	// Deployment ID.
-	ID *string `json:"id" validate:"required,ne="`
-
-	// Name of the logical replication slot.
-	Name *string `json:"name" validate:"required,ne="`
-
-	// Allows users to set headers on API requests
-	Headers map[string]string
-}
-
-// NewDeleteLogicalReplicationSlotOptions : Instantiate DeleteLogicalReplicationSlotOptions
-func (*CloudDatabasesV5) NewDeleteLogicalReplicationSlotOptions(id string, name string) *DeleteLogicalReplicationSlotOptions {
-	return &DeleteLogicalReplicationSlotOptions{
-		ID:   core.StringPtr(id),
-		Name: core.StringPtr(name),
-	}
-}
-
-// SetID : Allow user to set ID
-func (_options *DeleteLogicalReplicationSlotOptions) SetID(id string) *DeleteLogicalReplicationSlotOptions {
-	_options.ID = core.StringPtr(id)
-	return _options
-}
-
-// SetName : Allow user to set Name
-func (_options *DeleteLogicalReplicationSlotOptions) SetName(name string) *DeleteLogicalReplicationSlotOptions {
-	_options.Name = core.StringPtr(name)
-	return _options
-}
-
-// SetHeaders : Allow user to set Headers
-func (options *DeleteLogicalReplicationSlotOptions) SetHeaders(param map[string]string) *DeleteLogicalReplicationSlotOptions {
-	options.Headers = param
-	return options
-}
-
-// DeleteLogicalReplicationSlotResponse : DeleteLogicalReplicationSlotResponse struct
-type DeleteLogicalReplicationSlotResponse struct {
-	Task *Task `json:"task,omitempty"`
-}
-
-// UnmarshalDeleteLogicalReplicationSlotResponse unmarshals an instance of DeleteLogicalReplicationSlotResponse from the specified map of raw messages.
-func UnmarshalDeleteLogicalReplicationSlotResponse(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(DeleteLogicalReplicationSlotResponse)
 	err = core.UnmarshalModel(m, "task", &obj.Task, UnmarshalTask)
 	if err != nil {
 		return
@@ -3727,6 +3670,60 @@ type DeleteDatabaseUserResponse struct {
 // UnmarshalDeleteDatabaseUserResponse unmarshals an instance of DeleteDatabaseUserResponse from the specified map of raw messages.
 func UnmarshalDeleteDatabaseUserResponse(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(DeleteDatabaseUserResponse)
+	err = core.UnmarshalModel(m, "task", &obj.Task, UnmarshalTask)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// DeleteLogicalReplicationSlotOptions : The DeleteLogicalReplicationSlot options.
+type DeleteLogicalReplicationSlotOptions struct {
+	// Deployment ID.
+	ID *string `json:"id" validate:"required,ne="`
+
+	// Name of the logical replication slot.
+	Name *string `json:"name" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDeleteLogicalReplicationSlotOptions : Instantiate DeleteLogicalReplicationSlotOptions
+func (*CloudDatabasesV5) NewDeleteLogicalReplicationSlotOptions(id string, name string) *DeleteLogicalReplicationSlotOptions {
+	return &DeleteLogicalReplicationSlotOptions{
+		ID:   core.StringPtr(id),
+		Name: core.StringPtr(name),
+	}
+}
+
+// SetID : Allow user to set ID
+func (_options *DeleteLogicalReplicationSlotOptions) SetID(id string) *DeleteLogicalReplicationSlotOptions {
+	_options.ID = core.StringPtr(id)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *DeleteLogicalReplicationSlotOptions) SetName(name string) *DeleteLogicalReplicationSlotOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteLogicalReplicationSlotOptions) SetHeaders(param map[string]string) *DeleteLogicalReplicationSlotOptions {
+	options.Headers = param
+	return options
+}
+
+// DeleteLogicalReplicationSlotResponse : DeleteLogicalReplicationSlotResponse struct
+type DeleteLogicalReplicationSlotResponse struct {
+	Task *Task `json:"task,omitempty"`
+}
+
+// UnmarshalDeleteLogicalReplicationSlotResponse unmarshals an instance of DeleteLogicalReplicationSlotResponse from the specified map of raw messages.
+func UnmarshalDeleteLogicalReplicationSlotResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(DeleteLogicalReplicationSlotResponse)
 	err = core.UnmarshalModel(m, "task", &obj.Task, UnmarshalTask)
 	if err != nil {
 		return

--- a/clouddatabasesv5/cloud_databases_v5_examples_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_examples_test.go
@@ -31,7 +31,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//
 // This file provides an example of how to use the Cloud Databases service.
 //
 // The following configuration properties are assumed to be defined:
@@ -45,7 +44,6 @@ import (
 // These configuration properties can be exported as environment variables, or stored
 // in a configuration file and then:
 // export IBM_CREDENTIALS_FILE=<name of configuration file>
-//
 const externalConfigFile = "../cloud_databases.env"
 
 var (
@@ -341,11 +339,15 @@ var _ = Describe(`CloudDatabasesV5 Examples Tests`, func() {
 			fmt.Println("\nCreateLogicalReplicationSlot() result:")
 			// begin-createLogicalReplicationSlot
 
+			logicalReplicationSlot := &clouddatabasesv5.LogicalReplicationSlot{
+				Name:         &logicalRepName,
+				DatabaseName: &databaseName,
+				PluginType:   &pluginType,
+			}
+
 			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
-				ID:           deploymentID,
-				Name:         logicalRepName,
-				DatabaseName: databaseName,
-				PluginType:   pluginType,
+				ID:                     &deploymentID,
+				LogicalReplicationSlot: logicalReplicationSlot,
 			}
 
 			createLogicalReplicationResponse, response, err := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions)

--- a/clouddatabasesv5/cloud_databases_v5_examples_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_examples_test.go
@@ -337,16 +337,44 @@ var _ = Describe(`CloudDatabasesV5 Examples Tests`, func() {
 
 			waitForTask(taskIDLink)
 		})
+		It(`CreateLogicalReplicationSlot request example`, func() {
+			fmt.Println("\nCreateLogicalReplicationSlot() result:")
+			// begin-createLogicalReplicationSlot
+
+			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
+				ID:           deploymentID,
+				Name:         logicalRepName,
+				DatabaseName: databaseName,
+				PluginType:   pluginType,
+			}
+
+			createLogicalReplicationResponse, response, err := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(createLogicalReplicationResponse, "", "  ")
+			fmt.Println(string(b))
+
+			// end-createLogicalReplicationSlot
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(createLogicalReplicationResponse).ToNot(BeNil())
+
+			taskIDLink = *createLogicalReplicationResponse.Task.ID
+
+			waitForTask(taskIDLink)
+		})
 		It(`DeleteLogicalReplicationSlot request example`, func() {
 			fmt.Println("\nDeleteLogicalReplicationSlot() result:")
 			// begin-deleteLogicalReplicationSlot
 
-			deleteLogicalReplicationOptions := cloudDatabasesService.NewDeleteLogicalReplicationSlotOptions(
-				deploymentID,
-				logicalRepName,
-			)
+			deleteLogicalReplicationSlotOptions := &clouddatabasesv5.DeleteLogicalReplicationSlotOptions{
+				ID:   deploymentID,
+				Name: logicalRepName,
+			}
 
-			deleteLogicalReplicationResponse, response, err := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationOptions)
+			deleteLogicalReplicationResponse, response, err := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions)
 			if err != nil {
 				panic(err)
 			}

--- a/clouddatabasesv5/cloud_databases_v5_examples_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_examples_test.go
@@ -252,7 +252,7 @@ var _ = Describe(`CloudDatabasesV5 Examples Tests`, func() {
 			fmt.Println("\nCreateLogicalReplicationSlot() result:")
 			// begin-createLogicalReplicationSlot
 
-			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot{
+			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlot{
 				Name:         &logicalRepName,
 				DatabaseName: &databaseName,
 				PluginType:   &pluginType,

--- a/clouddatabasesv5/cloud_databases_v5_examples_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_examples_test.go
@@ -337,6 +337,32 @@ var _ = Describe(`CloudDatabasesV5 Examples Tests`, func() {
 
 			waitForTask(taskIDLink)
 		})
+		It(`DeleteLogicalReplicationSlot request example`, func() {
+			fmt.Println("\nDeleteLogicalReplicationSlot() result:")
+			// begin-deleteLogicalReplicationSlot
+
+			deleteLogicalReplicationOptions := cloudDatabasesService.NewDeleteLogicalReplicationSlotOptions(
+				deploymentID,
+				logicalRepName,
+			)
+
+			deleteLogicalReplicationResponse, response, err := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(deleteLogicalReplicationResponse, "", "  ")
+			fmt.Println(string(b))
+
+			// end-deleteLogicalReplicationSlot
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(deleteLogicalReplicationResponse).ToNot(BeNil())
+
+			taskIDLink = *deleteLogicalReplicationResponse.Task.ID
+
+			waitForTask(taskIDLink)
+		})
 		It(`KillConnections request example`, func() {
 			fmt.Println("\nKillConnections() result:")
 			// begin-killConnections

--- a/clouddatabasesv5/cloud_databases_v5_examples_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_examples_test.go
@@ -64,6 +64,9 @@ var (
 	replicaID          string
 	backupIDLink       string
 	scalingGroupIDLink string
+	logicalRepName     string = "wj123"
+	databaseName       string = "exampleDatabase"
+	pluginType         string = "wal2json"
 )
 
 // Globlal variables to hold link values
@@ -242,6 +245,36 @@ var _ = Describe(`CloudDatabasesV5 Examples Tests`, func() {
 			Expect(createDatabaseUserResponse).ToNot(BeNil())
 
 			taskIDLink = *createDatabaseUserResponse.Task.ID
+
+			waitForTask(taskIDLink)
+		})
+		It(`CreateLogicalReplicationSlot request example`, func() {
+			fmt.Println("\nCreateLogicalReplicationSlot() result:")
+			// begin-createLogicalReplicationSlot
+
+			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot{
+				Name:         &logicalRepName,
+				DatabaseName: &databaseName,
+				PluginType:   &pluginType,
+			}
+
+			createLogicalReplicationSlotOptions := cloudDatabasesService.NewCreateLogicalReplicationSlotOptions(deploymentID)
+			createLogicalReplicationSlotOptions.SetLogicalReplicationSlot(logicalReplicationSlotModel)
+
+			createLogicalReplicationResponse, response, err := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(createLogicalReplicationResponse, "", "  ")
+			fmt.Println(string(b))
+
+			// end-createLogicalReplicationSlot
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(createLogicalReplicationResponse).ToNot(BeNil())
+
+			taskIDLink = *createLogicalReplicationResponse.Task.ID
 
 			waitForTask(taskIDLink)
 		})

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -221,6 +221,35 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 	})
 
+	Describe(`CreateLogicalReplicationSlot - Creates a logical replication slot`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
+
+			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot{
+				Name:         core.StringPtr("wj123"),
+				DatabaseName: core.StringPtr("exampleDatabase"),
+				PluginType:   core.StringPtr("wal2json"),
+			}
+
+			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
+				ID:                     &deploymentID,
+				LogicalReplicationSlot: logicalReplicationSlotModel,
+			}
+
+			createLogicalReplicationResponse, response, err := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions)
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(createLogicalReplicationResponse).ToNot(BeNil())
+
+			taskIDLink = *createLogicalReplicationResponse.Task.ID
+
+			waitForTask(taskIDLink)
+		})
+	})
+
 	Describe(`ChangeUserPassword - Set specified user's password`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
@@ -269,6 +298,29 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 			Expect(deleteDatabaseUserResponse).ToNot(BeNil())
 
 			taskIDLink = *deleteDatabaseUserResponse.Task.ID
+
+			waitForTask(taskIDLink)
+		})
+	})
+
+	Describe(`DeleteLogicalReplicationSlot - Deletes a logical replication slot`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions)`, func() {
+
+			deleteLogicalReplicationSlotOptions := &clouddatabasesv5.DeleteLogicalReplicationSlotOptions{
+				ID:   &deploymentID,
+				Name: core.StringPtr("wj123"),
+			}
+
+			deleteLogicalReplicationResponse, response, err := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions)
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(deleteLogicalReplicationResponse).ToNot(BeNil())
+
+			taskIDLink = *deleteLogicalReplicationResponse.Task.ID
 
 			waitForTask(taskIDLink)
 		})

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -290,6 +290,7 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 	Describe(`KillConnections - Kill connections to a PostgreSQL or EnterpriseDB deployment`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
+			skipTestNotPGorEDB()
 		})
 		It(`KillConnections(killConnectionsOptions *KillConnectionsOptions)`, func() {
 
@@ -691,6 +692,7 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 	Describe(`GetPitrData - Get earliest point-in-time-recovery timestamp`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
+			skipTestNotPGorEDB()
 		})
 		It(`GetPitrData(getPitrDataOptions *GetPitrDataOptions)`, func() {
 

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -234,12 +234,6 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 		It(`ChangeUserPassword(changeUserPasswordOptions *ChangeUserPasswordOptions)`, func() {
 
-			var userName string = "user"
-
-			if strings.Contains(deploymentID, "postgresql") || strings.Contains(deploymentID, "enterprisedb") {
-				userName = "repl"
-			}
-
 			aPasswordSettingUserModel := &clouddatabasesv5.APasswordSettingUser{
 				Password: core.StringPtr("xyzzyyzzyx"),
 			}
@@ -247,7 +241,7 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 			changeUserPasswordOptions := &clouddatabasesv5.ChangeUserPasswordOptions{
 				ID:       &deploymentID,
 				UserType: core.StringPtr("database"),
-				Username: &userName,
+				Username: core.StringPtr("user"),
 				User:     aPasswordSettingUserModel,
 			}
 
@@ -395,19 +389,14 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 	Describe(`UpdateDatabaseConfiguration - Change your database configuration`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
+			skipTestNotPGorEDB()
 		})
 		It(`UpdateDatabaseConfiguration(updateDatabaseConfigurationOptions *UpdateDatabaseConfigurationOptions)`, func() {
 
 			configurationModel := &clouddatabasesv5.ConfigurationPgConfiguration{
 				MaxConnections: core.Int64Ptr(int64(200)),
-			}
-
-			if strings.Contains(deploymentID, "postgresql") || strings.Contains(deploymentID, "enterprisedb") {
-				configurationModel = &clouddatabasesv5.ConfigurationPgConfiguration{
-					MaxConnections: core.Int64Ptr(int64(200)),
-					WalLevel:       core.StringPtr("logical"),
-					MaxWalSenders:  core.Int64Ptr(int64(200)),
-				}
+				WalLevel:       core.StringPtr("logical"),
+				MaxWalSenders:  core.Int64Ptr(int64(200)),
 			}
 
 			updateDatabaseConfigurationOptions := cloudDatabasesService.NewUpdateDatabaseConfigurationOptions(
@@ -433,6 +422,23 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 			skipTestNotPGorEDB()
 		})
 		It(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
+
+			aPasswordSettingUserModel := &clouddatabasesv5.APasswordSettingUser{
+				Password: core.StringPtr("xyzzyyzzyx"),
+			}
+
+			changeUserPasswordOptions := &clouddatabasesv5.ChangeUserPasswordOptions{
+				ID:       &deploymentID,
+				UserType: core.StringPtr("database"),
+				Username: core.StringPtr("repl"),
+				User:     aPasswordSettingUserModel,
+			}
+
+			changeUserPasswordResponse, response, err := cloudDatabasesService.ChangeUserPassword(changeUserPasswordOptions)
+
+			passTaskIDLink := *changeUserPasswordResponse.Task.ID
+
+			waitForTask(passTaskIDLink)
 
 			logicalReplicationSlot := &clouddatabasesv5.LogicalReplicationSlot{
 				Name:         core.StringPtr("wj123"),

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -434,15 +434,11 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 		It(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
 
-			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlot{
+			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
+				ID:           &deploymentID,
 				Name:         core.StringPtr("wj123"),
 				DatabaseName: core.StringPtr("ibmclouddb"),
 				PluginType:   core.StringPtr("wal2json"),
-			}
-
-			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
-				ID:                     &deploymentID,
-				LogicalReplicationSlot: logicalReplicationSlotModel,
 			}
 
 			createLogicalReplicationResponse, response, err := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions)

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -221,35 +221,6 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateLogicalReplicationSlot - Creates a logical replication slot`, func() {
-		BeforeEach(func() {
-			shouldSkipTest()
-		})
-		It(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
-
-			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlot{
-				Name:         core.StringPtr("wj123"),
-				DatabaseName: core.StringPtr("exampleDatabase"),
-				PluginType:   core.StringPtr("wal2json"),
-			}
-
-			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
-				ID:                     &deploymentID,
-				LogicalReplicationSlot: logicalReplicationSlotModel,
-			}
-
-			createLogicalReplicationResponse, response, err := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions)
-
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(202))
-			Expect(createLogicalReplicationResponse).ToNot(BeNil())
-
-			taskIDLink = *createLogicalReplicationResponse.Task.ID
-
-			waitForTask(taskIDLink)
-		})
-	})
-
 	Describe(`ChangeUserPassword - Set specified user's password`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
@@ -263,7 +234,7 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 			changeUserPasswordOptions := &clouddatabasesv5.ChangeUserPasswordOptions{
 				ID:       &deploymentID,
 				UserType: core.StringPtr("database"),
-				Username: core.StringPtr("user"),
+				Username: core.StringPtr("repl"),
 				User:     aPasswordSettingUserModel,
 			}
 
@@ -298,29 +269,6 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 			Expect(deleteDatabaseUserResponse).ToNot(BeNil())
 
 			taskIDLink = *deleteDatabaseUserResponse.Task.ID
-
-			waitForTask(taskIDLink)
-		})
-	})
-
-	Describe(`DeleteLogicalReplicationSlot - Deletes a logical replication slot`, func() {
-		BeforeEach(func() {
-			shouldSkipTest()
-		})
-		It(`DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions)`, func() {
-
-			deleteLogicalReplicationSlotOptions := &clouddatabasesv5.DeleteLogicalReplicationSlotOptions{
-				ID:   &deploymentID,
-				Name: core.StringPtr("wj123"),
-			}
-
-			deleteLogicalReplicationResponse, response, err := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions)
-
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(202))
-			Expect(deleteLogicalReplicationResponse).ToNot(BeNil())
-
-			taskIDLink = *deleteLogicalReplicationResponse.Task.ID
 
 			waitForTask(taskIDLink)
 		})
@@ -438,6 +386,8 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 
 			configurationModel := &clouddatabasesv5.ConfigurationPgConfiguration{
 				MaxConnections: core.Int64Ptr(int64(200)),
+				WalLevel:       core.StringPtr("logical"),
+				MaxWalSenders:  core.Int64Ptr(int64(200)),
 			}
 
 			updateDatabaseConfigurationOptions := cloudDatabasesService.NewUpdateDatabaseConfigurationOptions(
@@ -457,6 +407,57 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 	})
 
+	Describe(`CreateLogicalReplicationSlot - Creates a logical replication slot`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
+
+			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlot{
+				Name:         core.StringPtr("wj123"),
+				DatabaseName: core.StringPtr("ibmclouddb"),
+				PluginType:   core.StringPtr("wal2json"),
+			}
+
+			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
+				ID:                     &deploymentID,
+				LogicalReplicationSlot: logicalReplicationSlotModel,
+			}
+
+			createLogicalReplicationResponse, response, err := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions)
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(createLogicalReplicationResponse).ToNot(BeNil())
+
+			taskIDLink = *createLogicalReplicationResponse.Task.ID
+
+			waitForTask(taskIDLink)
+		})
+	})
+
+	Describe(`DeleteLogicalReplicationSlot - Deletes a logical replication slot`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions)`, func() {
+
+			deleteLogicalReplicationSlotOptions := &clouddatabasesv5.DeleteLogicalReplicationSlotOptions{
+				ID:   &deploymentID,
+				Name: core.StringPtr("wj123"),
+			}
+
+			deleteLogicalReplicationResponse, response, err := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions)
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(deleteLogicalReplicationResponse).ToNot(BeNil())
+
+			taskIDLink = *deleteLogicalReplicationResponse.Task.ID
+
+			waitForTask(taskIDLink)
+		})
+	})
 	Describe(`ListDeployables - List all deployable databases`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -227,7 +227,7 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 		It(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
 
-			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot{
+			logicalReplicationSlotModel := &clouddatabasesv5.LogicalReplicationSlot{
 				Name:         core.StringPtr("wj123"),
 				DatabaseName: core.StringPtr("exampleDatabase"),
 				PluginType:   core.StringPtr("wal2json"),

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"strings"
 )
 
 /**
@@ -62,6 +63,12 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 
 	var shouldSkipTest = func() {
 		Skip("External configuration is not available, skipping tests...")
+	}
+
+	var skipTestNotPGorEDB = func() {
+		if !strings.Contains(deploymentID, "postgresql") && !strings.Contains(deploymentID, "enterprisedb") {
+			Skip("Not Postgresql or EDB, skipping tests...")
+		}
 	}
 
 	var waitForTask = func(taskID string) {
@@ -227,6 +234,12 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 		It(`ChangeUserPassword(changeUserPasswordOptions *ChangeUserPasswordOptions)`, func() {
 
+			var userName string = "user"
+
+			if strings.Contains(deploymentID, "postgresql") || strings.Contains(deploymentID, "enterprisedb") {
+				userName = "repl"
+			}
+
 			aPasswordSettingUserModel := &clouddatabasesv5.APasswordSettingUser{
 				Password: core.StringPtr("xyzzyyzzyx"),
 			}
@@ -234,7 +247,7 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 			changeUserPasswordOptions := &clouddatabasesv5.ChangeUserPasswordOptions{
 				ID:       &deploymentID,
 				UserType: core.StringPtr("database"),
-				Username: core.StringPtr("repl"),
+				Username: &userName,
 				User:     aPasswordSettingUserModel,
 			}
 
@@ -386,8 +399,14 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 
 			configurationModel := &clouddatabasesv5.ConfigurationPgConfiguration{
 				MaxConnections: core.Int64Ptr(int64(200)),
-				WalLevel:       core.StringPtr("logical"),
-				MaxWalSenders:  core.Int64Ptr(int64(200)),
+			}
+
+			if strings.Contains(deploymentID, "postgresql") || strings.Contains(deploymentID, "enterprisedb") {
+				configurationModel = &clouddatabasesv5.ConfigurationPgConfiguration{
+					MaxConnections: core.Int64Ptr(int64(200)),
+					WalLevel:       core.StringPtr("logical"),
+					MaxWalSenders:  core.Int64Ptr(int64(200)),
+				}
 			}
 
 			updateDatabaseConfigurationOptions := cloudDatabasesService.NewUpdateDatabaseConfigurationOptions(
@@ -410,6 +429,7 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 	Describe(`CreateLogicalReplicationSlot - Creates a logical replication slot`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
+			skipTestNotPGorEDB()
 		})
 		It(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
 
@@ -439,6 +459,7 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 	Describe(`DeleteLogicalReplicationSlot - Deletes a logical replication slot`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
+			skipTestNotPGorEDB()
 		})
 		It(`DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions)`, func() {
 

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -434,11 +434,15 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 		It(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
 
-			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
-				ID:           &deploymentID,
+			logicalReplicationSlot := &clouddatabasesv5.LogicalReplicationSlot{
 				Name:         core.StringPtr("wj123"),
 				DatabaseName: core.StringPtr("ibmclouddb"),
 				PluginType:   core.StringPtr("wal2json"),
+			}
+
+			createLogicalReplicationSlotOptions := &clouddatabasesv5.CreateLogicalReplicationSlotOptions{
+				ID:                     &deploymentID,
+				LogicalReplicationSlot: logicalReplicationSlot,
 			}
 
 			createLogicalReplicationResponse, response, err := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions)

--- a/clouddatabasesv5/cloud_databases_v5_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_test.go
@@ -5375,16 +5375,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
-				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
-				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
-				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+				// Construct an instance of the LogicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
 
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
@@ -5449,16 +5449,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(cloudDatabasesService).ToNot(BeNil())
 				cloudDatabasesService.EnableRetries(0, 0)
 
-				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
-				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
-				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+				// Construct an instance of the logicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
 
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -5531,16 +5531,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
-				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
-				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+				// Construct an instance of the logicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
 
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -5558,16 +5558,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
-				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
-				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
-				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+				// Construct an instance of the logicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
 
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := cloudDatabasesService.SetServiceURL("")
@@ -5606,16 +5606,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
-				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
-				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
-				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+				// Construct an instance of the logicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
 
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation

--- a/clouddatabasesv5/cloud_databases_v5_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_test.go
@@ -5352,6 +5352,602 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 			})
 		})
 	})
+	Describe(`SetAutoscalingConditions(setAutoscalingConditionsOptions *SetAutoscalingConditionsOptions) - Operation response error`, func() {
+		setAutoscalingConditionsPath := "/deployments/testString/groups/testString/autoscaling"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(setAutoscalingConditionsPath))
+					Expect(req.Method).To(Equal("PATCH"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke SetAutoscalingConditions with error: Operation response processing error`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
+				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
+				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
+				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
+				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10))
+				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
+				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
+				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
+
+				// Construct an instance of the AutoscalingMemoryGroupMemory model
+				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
+				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
+				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
+
+				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
+				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
+				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
+
+				// Construct an instance of the SetAutoscalingConditionsOptions model
+				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
+				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
+				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				cloudDatabasesService.EnableRetries(0, 0)
+				result, response, operationErr = cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`SetAutoscalingConditions(setAutoscalingConditionsOptions *SetAutoscalingConditionsOptions)`, func() {
+		setAutoscalingConditionsPath := "/deployments/testString/groups/testString/autoscaling"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(setAutoscalingConditionsPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
+				}))
+			})
+			It(`Invoke SetAutoscalingConditions successfully with retries`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+				cloudDatabasesService.EnableRetries(0, 0)
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
+				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
+				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
+				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
+				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10))
+				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
+				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
+				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
+
+				// Construct an instance of the AutoscalingMemoryGroupMemory model
+				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
+				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
+				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
+
+				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
+				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
+				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
+
+				// Construct an instance of the SetAutoscalingConditionsOptions model
+				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
+				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
+				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := cloudDatabasesService.SetAutoscalingConditionsWithContext(ctx, setAutoscalingConditionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				cloudDatabasesService.DisableRetries()
+				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = cloudDatabasesService.SetAutoscalingConditionsWithContext(ctx, setAutoscalingConditionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(setAutoscalingConditionsPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
+				}))
+			})
+			It(`Invoke SetAutoscalingConditions successfully`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
+				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
+				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
+				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
+				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10))
+				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
+				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
+				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
+
+				// Construct an instance of the AutoscalingMemoryGroupMemory model
+				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
+				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
+				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
+
+				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
+				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
+				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
+
+				// Construct an instance of the SetAutoscalingConditionsOptions model
+				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
+				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
+				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke SetAutoscalingConditions with error: Operation validation and request error`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
+				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
+				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
+				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
+				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10))
+				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
+				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
+				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
+
+				// Construct an instance of the AutoscalingMemoryGroupMemory model
+				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
+				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
+				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
+
+				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
+				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
+				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
+
+				// Construct an instance of the SetAutoscalingConditionsOptions model
+				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
+				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
+				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := cloudDatabasesService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the SetAutoscalingConditionsOptions model with no property values
+				setAutoscalingConditionsOptionsModelNew := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke SetAutoscalingConditions successfully`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
+				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
+				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
+				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
+
+				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
+				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
+				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10))
+				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
+				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
+				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
+
+				// Construct an instance of the AutoscalingMemoryGroupMemory model
+				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
+				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
+				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
+
+				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
+				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
+				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
+
+				// Construct an instance of the SetAutoscalingConditionsOptions model
+				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
+				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
+				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
+				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`KillConnections(killConnectionsOptions *KillConnectionsOptions) - Operation response error`, func() {
+		killConnectionsPath := "/deployments/testString/management/database_connections"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(killConnectionsPath))
+					Expect(req.Method).To(Equal("DELETE"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke KillConnections with error: Operation response processing error`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the KillConnectionsOptions model
+				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
+				killConnectionsOptionsModel.ID = core.StringPtr("testString")
+				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				cloudDatabasesService.EnableRetries(0, 0)
+				result, response, operationErr = cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`KillConnections(killConnectionsOptions *KillConnectionsOptions)`, func() {
+		killConnectionsPath := "/deployments/testString/management/database_connections"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(killConnectionsPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
+				}))
+			})
+			It(`Invoke KillConnections successfully with retries`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+				cloudDatabasesService.EnableRetries(0, 0)
+
+				// Construct an instance of the KillConnectionsOptions model
+				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
+				killConnectionsOptionsModel.ID = core.StringPtr("testString")
+				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := cloudDatabasesService.KillConnectionsWithContext(ctx, killConnectionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				cloudDatabasesService.DisableRetries()
+				result, response, operationErr := cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = cloudDatabasesService.KillConnectionsWithContext(ctx, killConnectionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(killConnectionsPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
+				}))
+			})
+			It(`Invoke KillConnections successfully`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := cloudDatabasesService.KillConnections(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the KillConnectionsOptions model
+				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
+				killConnectionsOptionsModel.ID = core.StringPtr("testString")
+				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke KillConnections with error: Operation validation and request error`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the KillConnectionsOptions model
+				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
+				killConnectionsOptionsModel.ID = core.StringPtr("testString")
+				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := cloudDatabasesService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the KillConnectionsOptions model with no property values
+				killConnectionsOptionsModelNew := new(clouddatabasesv5.KillConnectionsOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = cloudDatabasesService.KillConnections(killConnectionsOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke KillConnections successfully`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the KillConnectionsOptions model
+				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
+				killConnectionsOptionsModel.ID = core.StringPtr("testString")
+				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions) - Operation response error`, func() {
 		createLogicalReplicationSlotPath := "/deployments/testString/postgresql/logical_replication_slots"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
@@ -5375,16 +5971,12 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
-				// Construct an instance of the LogicalReplicationSlot model
-				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
-				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
-
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
@@ -5449,16 +6041,12 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(cloudDatabasesService).ToNot(BeNil())
 				cloudDatabasesService.EnableRetries(0, 0)
 
-				// Construct an instance of the logicalReplicationSlot model
-				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
-				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
-
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -5531,16 +6119,12 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the logicalReplicationSlot model
-				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
-				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
-
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -5558,16 +6142,12 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
-				// Construct an instance of the logicalReplicationSlot model
-				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
-				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
-
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := cloudDatabasesService.SetServiceURL("")
@@ -5606,16 +6186,12 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
-				// Construct an instance of the logicalReplicationSlot model
-				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
-				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
-				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
-				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
-
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -5643,7 +6219,7 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 					Expect(req.Method).To(Equal("DELETE"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(202)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke DeleteLogicalReplicationSlot with error: Operation response processing error`, func() {
@@ -5837,602 +6413,6 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 
 				// Invoke operation
 				result, response, operationErr := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptionsModel)
-				Expect(operationErr).To(BeNil())
-				Expect(response).ToNot(BeNil())
-
-				// Verify a nil result
-				Expect(result).To(BeNil())
-			})
-			AfterEach(func() {
-				testServer.Close()
-			})
-		})
-	})
-	Describe(`SetAutoscalingConditions(setAutoscalingConditionsOptions *SetAutoscalingConditionsOptions) - Operation response error`, func() {
-		setAutoscalingConditionsPath := "/deployments/testString/groups/testString/autoscaling"
-		Context(`Using mock server endpoint with invalid JSON response`, func() {
-			BeforeEach(func() {
-				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					defer GinkgoRecover()
-
-					// Verify the contents of the request
-					Expect(req.URL.EscapedPath()).To(Equal(setAutoscalingConditionsPath))
-					Expect(req.Method).To(Equal("PATCH"))
-					res.Header().Set("Content-type", "application/json")
-					res.WriteHeader(202)
-					fmt.Fprint(res, `} this is not valid json {`)
-				}))
-			})
-			It(`Invoke SetAutoscalingConditions with error: Operation response processing error`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
-				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
-				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
-				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
-				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10.0))
-				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
-				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
-				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
-
-				// Construct an instance of the AutoscalingMemoryGroupMemory model
-				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
-				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
-				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
-
-				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
-				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
-				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
-
-				// Construct an instance of the SetAutoscalingConditionsOptions model
-				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
-				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
-				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-				// Expect response parsing to fail since we are receiving a text/plain response
-				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).To(BeNil())
-
-				// Enable retries and test again
-				cloudDatabasesService.EnableRetries(0, 0)
-				result, response, operationErr = cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).To(BeNil())
-			})
-			AfterEach(func() {
-				testServer.Close()
-			})
-		})
-	})
-	Describe(`SetAutoscalingConditions(setAutoscalingConditionsOptions *SetAutoscalingConditionsOptions)`, func() {
-		setAutoscalingConditionsPath := "/deployments/testString/groups/testString/autoscaling"
-		Context(`Using mock server endpoint with timeout`, func() {
-			BeforeEach(func() {
-				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					defer GinkgoRecover()
-
-					// Verify the contents of the request
-					Expect(req.URL.EscapedPath()).To(Equal(setAutoscalingConditionsPath))
-					Expect(req.Method).To(Equal("PATCH"))
-
-					// For gzip-disabled operation, verify Content-Encoding is not set.
-					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
-
-					// If there is a body, then make sure we can read it
-					bodyBuf := new(bytes.Buffer)
-					if req.Header.Get("Content-Encoding") == "gzip" {
-						body, err := core.NewGzipDecompressionReader(req.Body)
-						Expect(err).To(BeNil())
-						_, err = bodyBuf.ReadFrom(body)
-						Expect(err).To(BeNil())
-					} else {
-						_, err := bodyBuf.ReadFrom(req.Body)
-						Expect(err).To(BeNil())
-					}
-					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
-
-					// Sleep a short time to support a timeout test
-					time.Sleep(100 * time.Millisecond)
-
-					// Set mock response
-					res.Header().Set("Content-type", "application/json")
-					res.WriteHeader(202)
-					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
-				}))
-			})
-			It(`Invoke SetAutoscalingConditions successfully with retries`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-				cloudDatabasesService.EnableRetries(0, 0)
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
-				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
-				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
-				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
-				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10.0))
-				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
-				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
-				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
-
-				// Construct an instance of the AutoscalingMemoryGroupMemory model
-				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
-				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
-				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
-
-				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
-				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
-				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
-
-				// Construct an instance of the SetAutoscalingConditionsOptions model
-				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
-				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
-				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-
-				// Invoke operation with a Context to test a timeout error
-				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
-				defer cancelFunc()
-				_, _, operationErr := cloudDatabasesService.SetAutoscalingConditionsWithContext(ctx, setAutoscalingConditionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
-
-				// Disable retries and test again
-				cloudDatabasesService.DisableRetries()
-				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
-				Expect(operationErr).To(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).ToNot(BeNil())
-
-				// Re-test the timeout error with retries disabled
-				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
-				defer cancelFunc2()
-				_, _, operationErr = cloudDatabasesService.SetAutoscalingConditionsWithContext(ctx, setAutoscalingConditionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
-			})
-			AfterEach(func() {
-				testServer.Close()
-			})
-		})
-		Context(`Using mock server endpoint`, func() {
-			BeforeEach(func() {
-				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					defer GinkgoRecover()
-
-					// Verify the contents of the request
-					Expect(req.URL.EscapedPath()).To(Equal(setAutoscalingConditionsPath))
-					Expect(req.Method).To(Equal("PATCH"))
-
-					// For gzip-disabled operation, verify Content-Encoding is not set.
-					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
-
-					// If there is a body, then make sure we can read it
-					bodyBuf := new(bytes.Buffer)
-					if req.Header.Get("Content-Encoding") == "gzip" {
-						body, err := core.NewGzipDecompressionReader(req.Body)
-						Expect(err).To(BeNil())
-						_, err = bodyBuf.ReadFrom(body)
-						Expect(err).To(BeNil())
-					} else {
-						_, err := bodyBuf.ReadFrom(req.Body)
-						Expect(err).To(BeNil())
-					}
-					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
-
-					// Set mock response
-					res.Header().Set("Content-type", "application/json")
-					res.WriteHeader(202)
-					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
-				}))
-			})
-			It(`Invoke SetAutoscalingConditions successfully`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-
-				// Invoke operation with nil options model (negative test)
-				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(nil)
-				Expect(operationErr).NotTo(BeNil())
-				Expect(response).To(BeNil())
-				Expect(result).To(BeNil())
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
-				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
-				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
-				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
-				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10.0))
-				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
-				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
-				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
-
-				// Construct an instance of the AutoscalingMemoryGroupMemory model
-				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
-				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
-				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
-
-				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
-				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
-				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
-
-				// Construct an instance of the SetAutoscalingConditionsOptions model
-				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
-				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
-				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-
-				// Invoke operation with valid options model (positive test)
-				result, response, operationErr = cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
-				Expect(operationErr).To(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).ToNot(BeNil())
-
-			})
-			It(`Invoke SetAutoscalingConditions with error: Operation validation and request error`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
-				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
-				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
-				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
-				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10.0))
-				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
-				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
-				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
-
-				// Construct an instance of the AutoscalingMemoryGroupMemory model
-				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
-				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
-				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
-
-				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
-				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
-				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
-
-				// Construct an instance of the SetAutoscalingConditionsOptions model
-				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
-				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
-				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-				// Invoke operation with empty URL (negative test)
-				err := cloudDatabasesService.SetServiceURL("")
-				Expect(err).To(BeNil())
-				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
-				Expect(response).To(BeNil())
-				Expect(result).To(BeNil())
-				// Construct a second instance of the SetAutoscalingConditionsOptions model with no property values
-				setAutoscalingConditionsOptionsModelNew := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
-				// Invoke operation with invalid model (negative test)
-				result, response, operationErr = cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModelNew)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(response).To(BeNil())
-				Expect(result).To(BeNil())
-			})
-			AfterEach(func() {
-				testServer.Close()
-			})
-		})
-		Context(`Using mock server endpoint with missing response body`, func() {
-			BeforeEach(func() {
-				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					defer GinkgoRecover()
-
-					// Set success status code with no respoonse body
-					res.WriteHeader(202)
-				}))
-			})
-			It(`Invoke SetAutoscalingConditions successfully`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalersIoUtilization model
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalersIoUtilization)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.Enabled = core.BoolPtr(true)
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.OverPeriod = core.StringPtr("5m")
-				autoscalingMemoryGroupMemoryScalersIoUtilizationModel.AbovePercent = core.Int64Ptr(int64(90))
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryScalers model
-				autoscalingMemoryGroupMemoryScalersModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryScalers)
-				autoscalingMemoryGroupMemoryScalersModel.IoUtilization = autoscalingMemoryGroupMemoryScalersIoUtilizationModel
-
-				// Construct an instance of the AutoscalingMemoryGroupMemoryRate model
-				autoscalingMemoryGroupMemoryRateModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemoryRate)
-				autoscalingMemoryGroupMemoryRateModel.IncreasePercent = core.Float64Ptr(float64(10.0))
-				autoscalingMemoryGroupMemoryRateModel.PeriodSeconds = core.Int64Ptr(int64(300))
-				autoscalingMemoryGroupMemoryRateModel.LimitMbPerMember = core.Float64Ptr(float64(125952))
-				autoscalingMemoryGroupMemoryRateModel.Units = core.StringPtr("mb")
-
-				// Construct an instance of the AutoscalingMemoryGroupMemory model
-				autoscalingMemoryGroupMemoryModel := new(clouddatabasesv5.AutoscalingMemoryGroupMemory)
-				autoscalingMemoryGroupMemoryModel.Scalers = autoscalingMemoryGroupMemoryScalersModel
-				autoscalingMemoryGroupMemoryModel.Rate = autoscalingMemoryGroupMemoryRateModel
-
-				// Construct an instance of the AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup model
-				autoscalingSetGroupAutoscalingModel := new(clouddatabasesv5.AutoscalingSetGroupAutoscalingAutoscalingMemoryGroup)
-				autoscalingSetGroupAutoscalingModel.Memory = autoscalingMemoryGroupMemoryModel
-
-				// Construct an instance of the SetAutoscalingConditionsOptions model
-				setAutoscalingConditionsOptionsModel := new(clouddatabasesv5.SetAutoscalingConditionsOptions)
-				setAutoscalingConditionsOptionsModel.ID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.GroupID = core.StringPtr("testString")
-				setAutoscalingConditionsOptionsModel.Autoscaling = autoscalingSetGroupAutoscalingModel
-				setAutoscalingConditionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-
-				// Invoke operation
-				result, response, operationErr := cloudDatabasesService.SetAutoscalingConditions(setAutoscalingConditionsOptionsModel)
-				Expect(operationErr).To(BeNil())
-				Expect(response).ToNot(BeNil())
-
-				// Verify a nil result
-				Expect(result).To(BeNil())
-			})
-			AfterEach(func() {
-				testServer.Close()
-			})
-		})
-	})
-	Describe(`KillConnections(killConnectionsOptions *KillConnectionsOptions) - Operation response error`, func() {
-		killConnectionsPath := "/deployments/testString/management/database_connections"
-		Context(`Using mock server endpoint with invalid JSON response`, func() {
-			BeforeEach(func() {
-				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					defer GinkgoRecover()
-
-					// Verify the contents of the request
-					Expect(req.URL.EscapedPath()).To(Equal(killConnectionsPath))
-					Expect(req.Method).To(Equal("DELETE"))
-					res.Header().Set("Content-type", "application/json")
-					res.WriteHeader(202)
-					fmt.Fprint(res, `} this is not valid json {`)
-				}))
-			})
-			It(`Invoke KillConnections with error: Operation response processing error`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-
-				// Construct an instance of the KillConnectionsOptions model
-				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
-				killConnectionsOptionsModel.ID = core.StringPtr("testString")
-				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-				// Expect response parsing to fail since we are receiving a text/plain response
-				result, response, operationErr := cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).To(BeNil())
-
-				// Enable retries and test again
-				cloudDatabasesService.EnableRetries(0, 0)
-				result, response, operationErr = cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).To(BeNil())
-			})
-			AfterEach(func() {
-				testServer.Close()
-			})
-		})
-	})
-	Describe(`KillConnections(killConnectionsOptions *KillConnectionsOptions)`, func() {
-		killConnectionsPath := "/deployments/testString/management/database_connections"
-		Context(`Using mock server endpoint with timeout`, func() {
-			BeforeEach(func() {
-				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					defer GinkgoRecover()
-
-					// Verify the contents of the request
-					Expect(req.URL.EscapedPath()).To(Equal(killConnectionsPath))
-					Expect(req.Method).To(Equal("DELETE"))
-
-					// Sleep a short time to support a timeout test
-					time.Sleep(100 * time.Millisecond)
-
-					// Set mock response
-					res.Header().Set("Content-type", "application/json")
-					res.WriteHeader(202)
-					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
-				}))
-			})
-			It(`Invoke KillConnections successfully with retries`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-				cloudDatabasesService.EnableRetries(0, 0)
-
-				// Construct an instance of the KillConnectionsOptions model
-				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
-				killConnectionsOptionsModel.ID = core.StringPtr("testString")
-				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-
-				// Invoke operation with a Context to test a timeout error
-				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
-				defer cancelFunc()
-				_, _, operationErr := cloudDatabasesService.KillConnectionsWithContext(ctx, killConnectionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
-
-				// Disable retries and test again
-				cloudDatabasesService.DisableRetries()
-				result, response, operationErr := cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
-				Expect(operationErr).To(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).ToNot(BeNil())
-
-				// Re-test the timeout error with retries disabled
-				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
-				defer cancelFunc2()
-				_, _, operationErr = cloudDatabasesService.KillConnectionsWithContext(ctx, killConnectionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
-			})
-			AfterEach(func() {
-				testServer.Close()
-			})
-		})
-		Context(`Using mock server endpoint`, func() {
-			BeforeEach(func() {
-				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					defer GinkgoRecover()
-
-					// Verify the contents of the request
-					Expect(req.URL.EscapedPath()).To(Equal(killConnectionsPath))
-					Expect(req.Method).To(Equal("DELETE"))
-
-					// Set mock response
-					res.Header().Set("Content-type", "application/json")
-					res.WriteHeader(202)
-					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
-				}))
-			})
-			It(`Invoke KillConnections successfully`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-
-				// Invoke operation with nil options model (negative test)
-				result, response, operationErr := cloudDatabasesService.KillConnections(nil)
-				Expect(operationErr).NotTo(BeNil())
-				Expect(response).To(BeNil())
-				Expect(result).To(BeNil())
-
-				// Construct an instance of the KillConnectionsOptions model
-				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
-				killConnectionsOptionsModel.ID = core.StringPtr("testString")
-				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-
-				// Invoke operation with valid options model (positive test)
-				result, response, operationErr = cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
-				Expect(operationErr).To(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).ToNot(BeNil())
-
-			})
-			It(`Invoke KillConnections with error: Operation validation and request error`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-
-				// Construct an instance of the KillConnectionsOptions model
-				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
-				killConnectionsOptionsModel.ID = core.StringPtr("testString")
-				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-				// Invoke operation with empty URL (negative test)
-				err := cloudDatabasesService.SetServiceURL("")
-				Expect(err).To(BeNil())
-				result, response, operationErr := cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
-				Expect(response).To(BeNil())
-				Expect(result).To(BeNil())
-				// Construct a second instance of the KillConnectionsOptions model with no property values
-				killConnectionsOptionsModelNew := new(clouddatabasesv5.KillConnectionsOptions)
-				// Invoke operation with invalid model (negative test)
-				result, response, operationErr = cloudDatabasesService.KillConnections(killConnectionsOptionsModelNew)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(response).To(BeNil())
-				Expect(result).To(BeNil())
-			})
-			AfterEach(func() {
-				testServer.Close()
-			})
-		})
-		Context(`Using mock server endpoint with missing response body`, func() {
-			BeforeEach(func() {
-				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					defer GinkgoRecover()
-
-					// Set success status code with no respoonse body
-					res.WriteHeader(202)
-				}))
-			})
-			It(`Invoke KillConnections successfully`, func() {
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-					URL:           testServer.URL,
-					Authenticator: &core.NoAuthAuthenticator{},
-				})
-				Expect(serviceErr).To(BeNil())
-				Expect(cloudDatabasesService).ToNot(BeNil())
-
-				// Construct an instance of the KillConnectionsOptions model
-				killConnectionsOptionsModel := new(clouddatabasesv5.KillConnectionsOptions)
-				killConnectionsOptionsModel.ID = core.StringPtr("testString")
-				killConnectionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
-
-				// Invoke operation
-				result, response, operationErr := cloudDatabasesService.KillConnections(killConnectionsOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 
@@ -7530,6 +7510,25 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(createDatabaseUserOptionsModel.User).To(Equal(userModel))
 				Expect(createDatabaseUserOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewCreateLogicalReplicationSlotOptions successfully`, func() {
+				// Construct an instance of the CreateLogicalReplicationSlotOptions model
+				id := "testString"
+				createLogicalReplicationSlotOptionsName := "testString"
+				createLogicalReplicationSlotOptionsDatabaseName := "testString"
+				createLogicalReplicationSlotOptionsPluginType := "testString"
+				createLogicalReplicationSlotOptionsModel := cloudDatabasesService.NewCreateLogicalReplicationSlotOptions(id, createLogicalReplicationSlotOptionsName, createLogicalReplicationSlotOptionsDatabaseName, createLogicalReplicationSlotOptionsPluginType)
+				createLogicalReplicationSlotOptionsModel.SetID("testString")
+				createLogicalReplicationSlotOptionsModel.SetName("testString")
+				createLogicalReplicationSlotOptionsModel.SetDatabaseName("testString")
+				createLogicalReplicationSlotOptionsModel.SetPluginType("testString")
+				createLogicalReplicationSlotOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createLogicalReplicationSlotOptionsModel).ToNot(BeNil())
+				Expect(createLogicalReplicationSlotOptionsModel.ID).To(Equal(core.StringPtr("testString")))
+				Expect(createLogicalReplicationSlotOptionsModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(createLogicalReplicationSlotOptionsModel.DatabaseName).To(Equal(core.StringPtr("testString")))
+				Expect(createLogicalReplicationSlotOptionsModel.PluginType).To(Equal(core.StringPtr("testString")))
+				Expect(createLogicalReplicationSlotOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewDeleteAllowlistEntryOptions successfully`, func() {
 				// Construct an instance of the DeleteAllowlistEntryOptions model
 				id := "testString"
@@ -7558,6 +7557,19 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(deleteDatabaseUserOptionsModel.UserType).To(Equal(core.StringPtr("database")))
 				Expect(deleteDatabaseUserOptionsModel.Username).To(Equal(core.StringPtr("user")))
 				Expect(deleteDatabaseUserOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewDeleteLogicalReplicationSlotOptions successfully`, func() {
+				// Construct an instance of the DeleteLogicalReplicationSlotOptions model
+				id := "testString"
+				name := "testString"
+				deleteLogicalReplicationSlotOptionsModel := cloudDatabasesService.NewDeleteLogicalReplicationSlotOptions(id, name)
+				deleteLogicalReplicationSlotOptionsModel.SetID("testString")
+				deleteLogicalReplicationSlotOptionsModel.SetName("testString")
+				deleteLogicalReplicationSlotOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(deleteLogicalReplicationSlotOptionsModel).ToNot(BeNil())
+				Expect(deleteLogicalReplicationSlotOptionsModel.ID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteLogicalReplicationSlotOptionsModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(deleteLogicalReplicationSlotOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetAllowlistOptions successfully`, func() {
 				// Construct an instance of the GetAllowlistOptions model

--- a/clouddatabasesv5/cloud_databases_v5_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_test.go
@@ -5971,12 +5971,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
+				// Construct an instance of the LogicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
@@ -6041,12 +6045,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(cloudDatabasesService).ToNot(BeNil())
 				cloudDatabasesService.EnableRetries(0, 0)
 
+				// Construct an instance of the LogicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -6119,12 +6127,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
+				// Construct an instance of the LogicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -6142,12 +6154,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
+				// Construct an instance of the LogicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := cloudDatabasesService.SetServiceURL("")
@@ -6186,12 +6202,16 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
 
+				// Construct an instance of the LogicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
 				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.DatabaseName = core.StringPtr("testString")
-				createLogicalReplicationSlotOptionsModel.PluginType = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotModel
 				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -7511,22 +7531,25 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(createDatabaseUserOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateLogicalReplicationSlotOptions successfully`, func() {
+				// Construct an instance of the LogicalReplicationSlot model
+				logicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlot)
+				Expect(logicalReplicationSlotModel).ToNot(BeNil())
+				logicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+				Expect(logicalReplicationSlotModel.Name).To(Equal(core.StringPtr("customer_replication")))
+				Expect(logicalReplicationSlotModel.DatabaseName).To(Equal(core.StringPtr("customers")))
+				Expect(logicalReplicationSlotModel.PluginType).To(Equal(core.StringPtr("wal2json")))
+
 				// Construct an instance of the CreateLogicalReplicationSlotOptions model
 				id := "testString"
-				createLogicalReplicationSlotOptionsName := "testString"
-				createLogicalReplicationSlotOptionsDatabaseName := "testString"
-				createLogicalReplicationSlotOptionsPluginType := "testString"
-				createLogicalReplicationSlotOptionsModel := cloudDatabasesService.NewCreateLogicalReplicationSlotOptions(id, createLogicalReplicationSlotOptionsName, createLogicalReplicationSlotOptionsDatabaseName, createLogicalReplicationSlotOptionsPluginType)
+				createLogicalReplicationSlotOptionsModel := cloudDatabasesService.NewCreateLogicalReplicationSlotOptions(id)
 				createLogicalReplicationSlotOptionsModel.SetID("testString")
-				createLogicalReplicationSlotOptionsModel.SetName("testString")
-				createLogicalReplicationSlotOptionsModel.SetDatabaseName("testString")
-				createLogicalReplicationSlotOptionsModel.SetPluginType("testString")
+				createLogicalReplicationSlotOptionsModel.SetLogicalReplicationSlot(logicalReplicationSlotModel)
 				createLogicalReplicationSlotOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createLogicalReplicationSlotOptionsModel).ToNot(BeNil())
 				Expect(createLogicalReplicationSlotOptionsModel.ID).To(Equal(core.StringPtr("testString")))
-				Expect(createLogicalReplicationSlotOptionsModel.Name).To(Equal(core.StringPtr("testString")))
-				Expect(createLogicalReplicationSlotOptionsModel.DatabaseName).To(Equal(core.StringPtr("testString")))
-				Expect(createLogicalReplicationSlotOptionsModel.PluginType).To(Equal(core.StringPtr("testString")))
+				Expect(createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot).To(Equal(logicalReplicationSlotModel))
 				Expect(createLogicalReplicationSlotOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewDeleteAllowlistEntryOptions successfully`, func() {
@@ -7728,6 +7751,14 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(listRemotesOptionsModel).ToNot(BeNil())
 				Expect(listRemotesOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(listRemotesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewLogicalReplicationSlot successfully`, func() {
+				name := "customer_replication"
+				databaseName := "customers"
+				pluginType := "wal2json"
+				_model, err := cloudDatabasesService.NewLogicalReplicationSlot(name, databaseName, pluginType)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewPromoteReadOnlyReplicaOptions successfully`, func() {
 				// Construct an instance of the PromoteReadOnlyReplicaOptions model

--- a/clouddatabasesv5/cloud_databases_v5_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_test.go
@@ -5352,6 +5352,285 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 			})
 		})
 	})
+	Describe(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions) - Operation response error`, func() {
+		createLogicalReplicationSlotPath := "/deployments/testString/postgresql/logical_replication_slots"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createLogicalReplicationSlotPath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateLogicalReplicationSlot with error: Operation response processing error`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
+				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
+				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
+				// Construct an instance of the CreateLogicalReplicationSlotOptions model
+				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
+				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				cloudDatabasesService.EnableRetries(0, 0)
+				result, response, operationErr = cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateLogicalReplicationSlot(createLogicalReplicationSlotOptions *CreateLogicalReplicationSlotOptions)`, func() {
+		createLogicalReplicationSlotPath := "/deployments/testString/postgresql/logical_replication_slots"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createLogicalReplicationSlotPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
+				}))
+			})
+			It(`Invoke CreateLogicalReplicationSlot successfully with retries`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+				cloudDatabasesService.EnableRetries(0, 0)
+
+				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
+				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
+				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
+				// Construct an instance of the CreateLogicalReplicationSlotOptions model
+				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
+				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := cloudDatabasesService.CreateLogicalReplicationSlotWithContext(ctx, createLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				cloudDatabasesService.DisableRetries()
+				result, response, operationErr := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = cloudDatabasesService.CreateLogicalReplicationSlotWithContext(ctx, createLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createLogicalReplicationSlotPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
+				}))
+			})
+			It(`Invoke CreateLogicalReplicationSlot successfully`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := cloudDatabasesService.CreateLogicalReplicationSlot(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
+				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
+				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
+				// Construct an instance of the CreateLogicalReplicationSlotOptions model
+				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
+				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateLogicalReplicationSlot with error: Operation validation and request error`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
+				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
+				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
+				// Construct an instance of the CreateLogicalReplicationSlotOptions model
+				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
+				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := cloudDatabasesService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the CreateLogicalReplicationSlotOptions model with no property values
+				createLogicalReplicationSlotOptionsModelNew := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke CreateLogicalReplicationSlot successfully`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the LogicalReplicationSlotLogicalReplicationSlot model
+				logicalReplicationSlotLogicalReplicationSlotModel := new(clouddatabasesv5.LogicalReplicationSlotLogicalReplicationSlot)
+				logicalReplicationSlotLogicalReplicationSlotModel.Name = core.StringPtr("customer_replication")
+				logicalReplicationSlotLogicalReplicationSlotModel.DatabaseName = core.StringPtr("customers")
+				logicalReplicationSlotLogicalReplicationSlotModel.PluginType = core.StringPtr("wal2json")
+
+				// Construct an instance of the CreateLogicalReplicationSlotOptions model
+				createLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.CreateLogicalReplicationSlotOptions)
+				createLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				createLogicalReplicationSlotOptionsModel.LogicalReplicationSlot = logicalReplicationSlotLogicalReplicationSlotModel
+				createLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := cloudDatabasesService.CreateLogicalReplicationSlot(createLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`SetAutoscalingConditions(setAutoscalingConditionsOptions *SetAutoscalingConditionsOptions) - Operation response error`, func() {
 		setAutoscalingConditionsPath := "/deployments/testString/groups/testString/autoscaling"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {

--- a/clouddatabasesv5/cloud_databases_v5_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_test.go
@@ -5631,6 +5631,223 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 			})
 		})
 	})
+	Describe(`DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions) - Operation response error`, func() {
+		deleteLogicalReplicationSlotPath := "/deployments/testString/postgresql/logical_replication_slots/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteLogicalReplicationSlotPath))
+					Expect(req.Method).To(Equal("DELETE"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke DeleteLogicalReplicationSlot with error: Operation response processing error`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteLogicalReplicationSlotOptions model
+				deleteLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.DeleteLogicalReplicationSlotOptions)
+				deleteLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				cloudDatabasesService.EnableRetries(0, 0)
+				result, response, operationErr = cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptions *DeleteLogicalReplicationSlotOptions)`, func() {
+		deleteLogicalReplicationSlotPath := "/deployments/testString/postgresql/logical_replication_slots/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteLogicalReplicationSlotPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
+				}))
+			})
+			It(`Invoke DeleteLogicalReplicationSlot successfully with retries`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+				cloudDatabasesService.EnableRetries(0, 0)
+
+				// Construct an instance of the DeleteLogicalReplicationSlotOptions model
+				deleteLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.DeleteLogicalReplicationSlotOptions)
+				deleteLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := cloudDatabasesService.DeleteLogicalReplicationSlotWithContext(ctx, deleteLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				cloudDatabasesService.DisableRetries()
+				result, response, operationErr := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = cloudDatabasesService.DeleteLogicalReplicationSlotWithContext(ctx, deleteLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteLogicalReplicationSlotPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"task": {"id": "ID", "description": "Description", "status": "running", "deployment_id": "DeploymentID", "progress_percent": 15, "created_at": "2019-01-01T12:00:00.000Z"}}`)
+				}))
+			})
+			It(`Invoke DeleteLogicalReplicationSlot successfully`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := cloudDatabasesService.DeleteLogicalReplicationSlot(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the DeleteLogicalReplicationSlotOptions model
+				deleteLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.DeleteLogicalReplicationSlotOptions)
+				deleteLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke DeleteLogicalReplicationSlot with error: Operation validation and request error`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteLogicalReplicationSlotOptions model
+				deleteLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.DeleteLogicalReplicationSlotOptions)
+				deleteLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := cloudDatabasesService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the DeleteLogicalReplicationSlotOptions model with no property values
+				deleteLogicalReplicationSlotOptionsModelNew := new(clouddatabasesv5.DeleteLogicalReplicationSlotOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke DeleteLogicalReplicationSlot successfully`, func() {
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(cloudDatabasesService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteLogicalReplicationSlotOptions model
+				deleteLogicalReplicationSlotOptionsModel := new(clouddatabasesv5.DeleteLogicalReplicationSlotOptions)
+				deleteLogicalReplicationSlotOptionsModel.ID = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Name = core.StringPtr("testString")
+				deleteLogicalReplicationSlotOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := cloudDatabasesService.DeleteLogicalReplicationSlot(deleteLogicalReplicationSlotOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`SetAutoscalingConditions(setAutoscalingConditionsOptions *SetAutoscalingConditionsOptions) - Operation response error`, func() {
 		setAutoscalingConditionsPath := "/deployments/testString/groups/testString/autoscaling"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

We support the creation and deletion of logical replication slots in our API and CLI as seen here: https://cloud.ibm.com/apidocs/cloud-databases-api/cloud-databases-api-v5#createlogicalreplicationslot

However, we do not support it in our current Terraform integration. Terraform relies on our `cloud-databases-go-sdk` to perform API calls, and hence the ability to create and delete logical replication slots must be added to our `go-sdk`.

The work in this PR mainly revolves around the following two methods:
- `CreateLogicalReplicationSlot` - which creates logical replication slots
- `DeleteLogicalReplicationSlot` - which deletes logical replication slots

**Fixes:** I noticed 2 `IT` tests that were only intended for `PG` and `EDB` were running for other DB types and hence failing. I added a `skipTestNotPGorEDB` to resolve this issue.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

Not modifying current behavior.

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

At the moment we do not support the creation or deletion of logical replication slots. This PR gives developers the ability to contact the logical replication slot API and utilize it in their code.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

N/A

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
Passing `IT`
```
make test-int
go test `go list ./...` -tags=integration
ok  	github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5	317.285s
ok  	github.com/IBM/cloud-databases-go-sdk/common	0.196s
```