### PR TITLE
Update .secrets.baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-11T18:18:16Z",
+  "generated_at": "2024-11-22T10:46:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "1554d9572d4a498a75435316791c8b14f4736841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1291,
+        "line_number": 1461,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "6452e7c5a42f97b00af1a210afc7d4de315e57ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2718,
+        "line_number": 3061,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -136,7 +136,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 60,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -144,7 +144,7 @@
         "hashed_secret": "db0250fb0113c08308cd2db66dbf01cd55e62929",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3340,
+        "line_number": 3347,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -152,7 +152,7 @@
         "hashed_secret": "f62b2b62c78daacad075af2a045bb7290c909190",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3340,
+        "line_number": 3347,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -160,13 +160,21 @@
         "hashed_secret": "eef74311338b492868935e11afa97854dfe273dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8019,
+        "line_number": 8071,
         "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "86f528ff713b453058af8e761eac1ab0be09646f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8819,
+        "type": "Base64 High Entropy String",
         "verified_result": null
       }
     ]
   },
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.63.dss",
   "word_list": {
     "file": null,
     "hash": null


### PR DESCRIPTION
IBM's monitoring of external repos is failing with:

```
06:42:42  Failed Condition    Secret Type                 Filename                                       Line
06:42:42  ------------------  --------------------------  -------------------------------------------  ------
06:42:42  Unaudited           Base64 High Entropy String  clouddatabasesv5/cloud_databases_v5_test.go    8819
```

There is no pre-commit on this repo so I ran:

```
detect-secrets scan --update .secrets.baseline
detect-secrets audit .secrets.baseline
```

References: https://github.com/IBM/cloud-databases-go-sdk/pull/28