### PR TITLE
fix(Cloud Databases) include hidden and beta versions in upgrades

### DIFF
--- a/clouddatabasesv5/cloud_databases_v5.go
+++ b/clouddatabasesv5/cloud_databases_v5.go
@@ -2539,6 +2539,12 @@ func (cloudDatabases *CloudDatabasesV5) GetDeploymentCapabilityWithContext(ctx c
 	if getDeploymentCapabilityOptions.HostFlavor != nil {
 		builder.AddQuery("host_flavor", fmt.Sprint(*getDeploymentCapabilityOptions.HostFlavor))
 	}
+	if getDeploymentCapabilityOptions.IncludeHidden != nil {
+		builder.AddQuery("include_hidden", fmt.Sprint(*getDeploymentCapabilityOptions.IncludeHidden))
+	}
+	if getDeploymentCapabilityOptions.IncludeBeta != nil {
+		builder.AddQuery("include_beta", fmt.Sprint(*getDeploymentCapabilityOptions.IncludeBeta))
+	}
 
 	request, err := builder.Build()
 	if err != nil {
@@ -5372,6 +5378,12 @@ type GetDeploymentCapabilityOptions struct {
 	// will be returned.
 	HostFlavor *string `json:"host_flavor,omitempty"`
 
+	// Include hidden versions. Only applicable for versions capability.
+	IncludeHidden *bool `json:"include_hidden,omitempty"`
+
+	// Include beta versions. Only applicable for versions capability.
+	IncludeBeta *bool `json:"include_beta,omitempty"`
+
 	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
@@ -5424,6 +5436,18 @@ func (_options *GetDeploymentCapabilityOptions) SetTargetLocation(targetLocation
 // SetHostFlavor : Allow user to set HostFlavor
 func (_options *GetDeploymentCapabilityOptions) SetHostFlavor(hostFlavor string) *GetDeploymentCapabilityOptions {
 	_options.HostFlavor = core.StringPtr(hostFlavor)
+	return _options
+}
+
+// SetIncludeHidden : Allow user to set IncludeHidden
+func (_options *GetDeploymentCapabilityOptions) SetIncludeHidden(includeHidden bool) *GetDeploymentCapabilityOptions {
+	_options.IncludeHidden = core.BoolPtr(includeHidden)
+	return _options
+}
+
+// SetIncludeBeta : Allow user to set IncludeBeta
+func (_options *GetDeploymentCapabilityOptions) SetIncludeBeta(includeBeta bool) *GetDeploymentCapabilityOptions {
+	_options.IncludeBeta = core.BoolPtr(includeBeta)
 	return _options
 }
 

--- a/clouddatabasesv5/cloud_databases_v5_examples_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_examples_test.go
@@ -997,8 +997,8 @@ var _ = Describe(`CloudDatabasesV5 Examples Tests`, func() {
 			// begin-createCapability
 
 			createCapabilityRequestDeploymentModel := &clouddatabasesv5.CreateCapabilityRequestDeployment{
-				Type: core.StringPtr("postgresql"),
-				Version: core.StringPtr("10"),
+				Type:     core.StringPtr("postgresql"),
+				Version:  core.StringPtr("10"),
 				Platform: core.StringPtr("classic"),
 				Location: core.StringPtr("us-south"),
 			}
@@ -1032,6 +1032,8 @@ var _ = Describe(`CloudDatabasesV5 Examples Tests`, func() {
 			getDeploymentCapabilityOptions.SetTargetPlatform("target_platform=classic")
 			getDeploymentCapabilityOptions.SetTargetLocation("target_location=us-east")
 			getDeploymentCapabilityOptions.SetHostFlavor("host_flavor=multitenant")
+			getDeploymentCapabilityOptions.SetIncludeHidden(true)
+			getDeploymentCapabilityOptions.SetIncludeBeta(true)
 
 			getDeploymentCapabilityResponse, response, err := cloudDatabasesService.GetDeploymentCapability(getDeploymentCapabilityOptions)
 			if err != nil {

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -1133,16 +1133,16 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 		It(`CreateCapability(createCapabilityOptions *CreateCapabilityOptions)`, func() {
 			createCapabilityRequestDeploymentModel := &clouddatabasesv5.CreateCapabilityRequestDeployment{
-				Type: core.StringPtr("postgresql"),
-				Version: core.StringPtr("10"),
+				Type:     core.StringPtr("postgresql"),
+				Version:  core.StringPtr("10"),
 				Platform: core.StringPtr("classic"),
 				Location: core.StringPtr("us-south"),
-				Plan: core.StringPtr("standard"),
+				Plan:     core.StringPtr("standard"),
 			}
 
 			createCapabilityRequestBackupModel := &clouddatabasesv5.CreateCapabilityRequestBackup{
-				Type: core.StringPtr("PostgreSQL"),
-				Version: core.StringPtr("10"),
+				Type:     core.StringPtr("PostgreSQL"),
+				Version:  core.StringPtr("10"),
 				Platform: core.StringPtr("satellite"),
 				Location: core.StringPtr("us-south"),
 			}
@@ -1150,14 +1150,14 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 			createCapabilityRequestOptionsModel := &clouddatabasesv5.CreateCapabilityRequestOptions{
 				TargetPlatform: core.StringPtr("classic"),
 				TargetLocation: core.StringPtr("us-east"),
-				HostFlavor: core.StringPtr("multitenant"),
+				HostFlavor:     core.StringPtr("multitenant"),
 			}
 
 			createCapabilityOptions := &clouddatabasesv5.CreateCapabilityOptions{
 				CapabilityID: core.StringPtr("autoscaling"),
-				Deployment: createCapabilityRequestDeploymentModel,
-				Backup: createCapabilityRequestBackupModel,
-				Options: createCapabilityRequestOptionsModel,
+				Deployment:   createCapabilityRequestDeploymentModel,
+				Backup:       createCapabilityRequestBackupModel,
+				Options:      createCapabilityRequestOptionsModel,
 			}
 
 			createCapabilityResponse, response, err := cloudDatabasesService.CreateCapability(createCapabilityOptions)
@@ -1173,11 +1173,13 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		})
 		It(`GetDeploymentCapability(getDeploymentCapabilityOptions *GetDeploymentCapabilityOptions)`, func() {
 			getDeploymentCapabilityOptions := &clouddatabasesv5.GetDeploymentCapabilityOptions{
-				ID: &deploymentID,
-				CapabilityID: core.StringPtr("autoscaling"),
+				ID:             &deploymentID,
+				CapabilityID:   core.StringPtr("autoscaling"),
 				TargetPlatform: core.StringPtr("target_platform=classic"),
 				TargetLocation: core.StringPtr("target_location=us-east"),
-				HostFlavor: core.StringPtr("host_flavor=multitenant"),
+				HostFlavor:     core.StringPtr("host_flavor=multitenant"),
+				IncludeHidden:  core.BoolPtr(true),
+				IncludeBeta:    core.BoolPtr(true),
 			}
 
 			getDeploymentCapabilityResponse, response, err := cloudDatabasesService.GetDeploymentCapability(getDeploymentCapabilityOptions)
@@ -1194,8 +1196,8 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		It(`SetDatabaseInplaceVersionUpgrade(setDatabaseInplaceVersionUpgradeOptions *SetDatabaseInplaceVersionUpgradeOptions)`, func() {
 			// If failing check validation message as you ned to edit the version if deprecated
 			setDatabaseInplaceVersionUpgradeOptions := &clouddatabasesv5.SetDatabaseInplaceVersionUpgradeOptions{
-				ID: &deploymentID,
-				Version: core.StringPtr("7.0"),
+				ID:         &deploymentID,
+				Version:    core.StringPtr("7.0"),
 				SkipBackup: core.BoolPtr(true),
 			}
 

--- a/clouddatabasesv5/cloud_databases_v5_integration_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_integration_test.go
@@ -84,6 +84,12 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 		}
 	}
 
+	var skipTestNotMongo = func() {
+		if !strings.Contains(deploymentID, "mongodb") {
+			Skip("Not Mongo, skipping tests...")
+		}
+	}
+
 	var skipTestConfiguration = func() {
 		if !strings.Contains(deploymentID, "postgresql") && !strings.Contains(deploymentID, "enterprisedb") && !strings.Contains(deploymentID, "redis") && !strings.Contains(deploymentID, "mysql") {
 			Skip("Cannot configure resource, skipping tests...")
@@ -1192,12 +1198,13 @@ var _ = Describe(`CloudDatabasesV5 Integration Tests`, func() {
 	Describe(`SetDatabaseInplaceVersionUpgrade - Upgrade your database version`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
+			skipTestNotMongo()
 		})
 		It(`SetDatabaseInplaceVersionUpgrade(setDatabaseInplaceVersionUpgradeOptions *SetDatabaseInplaceVersionUpgradeOptions)`, func() {
 			// If failing check validation message as you ned to edit the version if deprecated
 			setDatabaseInplaceVersionUpgradeOptions := &clouddatabasesv5.SetDatabaseInplaceVersionUpgradeOptions{
 				ID:         &deploymentID,
-				Version:    core.StringPtr("7.0"),
+				Version:    core.StringPtr("8.0"),
 				SkipBackup: core.BoolPtr(true),
 			}
 

--- a/clouddatabasesv5/cloud_databases_v5_test.go
+++ b/clouddatabasesv5/cloud_databases_v5_test.go
@@ -68,14 +68,13 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"CLOUD_DATABASES_URL": "https://clouddatabasesv5/api",
+				"CLOUD_DATABASES_URL":       "https://clouddatabasesv5/api",
 				"CLOUD_DATABASES_AUTH_TYPE": "noauth",
 			}
 
 			It(`Create service client using external config successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5UsingExternalConfig(&clouddatabasesv5.CloudDatabasesV5Options{
-				})
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5UsingExternalConfig(&clouddatabasesv5.CloudDatabasesV5Options{})
 				Expect(cloudDatabasesService).ToNot(BeNil())
 				Expect(serviceErr).To(BeNil())
 				ClearTestEnvironment(testEnvironment)
@@ -104,8 +103,7 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 			})
 			It(`Create service client using external config and set url programatically successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5UsingExternalConfig(&clouddatabasesv5.CloudDatabasesV5Options{
-				})
+				cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5UsingExternalConfig(&clouddatabasesv5.CloudDatabasesV5Options{})
 				err := cloudDatabasesService.SetServiceURL("https://testService/api")
 				Expect(err).To(BeNil())
 				Expect(cloudDatabasesService).ToNot(BeNil())
@@ -123,13 +121,12 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"CLOUD_DATABASES_URL": "https://clouddatabasesv5/api",
+				"CLOUD_DATABASES_URL":       "https://clouddatabasesv5/api",
 				"CLOUD_DATABASES_AUTH_TYPE": "someOtherAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
-			cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5UsingExternalConfig(&clouddatabasesv5.CloudDatabasesV5Options{
-			})
+			cloudDatabasesService, serviceErr := clouddatabasesv5.NewCloudDatabasesV5UsingExternalConfig(&clouddatabasesv5.CloudDatabasesV5Options{})
 
 			It(`Instantiate service client with error`, func() {
 				Expect(cloudDatabasesService).To(BeNil())
@@ -140,7 +137,7 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"CLOUD_DATABASES_AUTH_TYPE":   "NOAuth",
+				"CLOUD_DATABASES_AUTH_TYPE": "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
@@ -7871,6 +7868,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 					Expect(req.URL.Query()["target_platform"]).To(Equal([]string{"target_platform=classic"}))
 					Expect(req.URL.Query()["target_location"]).To(Equal([]string{"target_location=us-east"}))
 					Expect(req.URL.Query()["host_flavor"]).To(Equal([]string{"host_flavor=multitenant"}))
+					// TODO: Add check for include_hidden query parameter
+					// TODO: Add check for include_beta query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
 					fmt.Fprint(res, `} this is not valid json {`)
@@ -7891,6 +7890,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				getDeploymentCapabilityOptionsModel.TargetPlatform = core.StringPtr("target_platform=classic")
 				getDeploymentCapabilityOptionsModel.TargetLocation = core.StringPtr("target_location=us-east")
 				getDeploymentCapabilityOptionsModel.HostFlavor = core.StringPtr("host_flavor=multitenant")
+				getDeploymentCapabilityOptionsModel.IncludeHidden = core.BoolPtr(true)
+				getDeploymentCapabilityOptionsModel.IncludeBeta = core.BoolPtr(true)
 				getDeploymentCapabilityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := cloudDatabasesService.GetDeploymentCapability(getDeploymentCapabilityOptionsModel)
@@ -7924,6 +7925,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 					Expect(req.URL.Query()["target_platform"]).To(Equal([]string{"target_platform=classic"}))
 					Expect(req.URL.Query()["target_location"]).To(Equal([]string{"target_location=us-east"}))
 					Expect(req.URL.Query()["host_flavor"]).To(Equal([]string{"host_flavor=multitenant"}))
+					// TODO: Add check for include_hidden query parameter
+					// TODO: Add check for include_beta query parameter
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
 
@@ -7949,6 +7952,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				getDeploymentCapabilityOptionsModel.TargetPlatform = core.StringPtr("target_platform=classic")
 				getDeploymentCapabilityOptionsModel.TargetLocation = core.StringPtr("target_location=us-east")
 				getDeploymentCapabilityOptionsModel.HostFlavor = core.StringPtr("host_flavor=multitenant")
+				getDeploymentCapabilityOptionsModel.IncludeHidden = core.BoolPtr(true)
+				getDeploymentCapabilityOptionsModel.IncludeBeta = core.BoolPtr(true)
 				getDeploymentCapabilityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -7988,6 +7993,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 					Expect(req.URL.Query()["target_platform"]).To(Equal([]string{"target_platform=classic"}))
 					Expect(req.URL.Query()["target_location"]).To(Equal([]string{"target_location=us-east"}))
 					Expect(req.URL.Query()["host_flavor"]).To(Equal([]string{"host_flavor=multitenant"}))
+					// TODO: Add check for include_hidden query parameter
+					// TODO: Add check for include_beta query parameter
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -8015,6 +8022,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				getDeploymentCapabilityOptionsModel.TargetPlatform = core.StringPtr("target_platform=classic")
 				getDeploymentCapabilityOptionsModel.TargetLocation = core.StringPtr("target_location=us-east")
 				getDeploymentCapabilityOptionsModel.HostFlavor = core.StringPtr("host_flavor=multitenant")
+				getDeploymentCapabilityOptionsModel.IncludeHidden = core.BoolPtr(true)
+				getDeploymentCapabilityOptionsModel.IncludeBeta = core.BoolPtr(true)
 				getDeploymentCapabilityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -8039,6 +8048,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				getDeploymentCapabilityOptionsModel.TargetPlatform = core.StringPtr("target_platform=classic")
 				getDeploymentCapabilityOptionsModel.TargetLocation = core.StringPtr("target_location=us-east")
 				getDeploymentCapabilityOptionsModel.HostFlavor = core.StringPtr("host_flavor=multitenant")
+				getDeploymentCapabilityOptionsModel.IncludeHidden = core.BoolPtr(true)
+				getDeploymentCapabilityOptionsModel.IncludeBeta = core.BoolPtr(true)
 				getDeploymentCapabilityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := cloudDatabasesService.SetServiceURL("")
@@ -8084,6 +8095,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				getDeploymentCapabilityOptionsModel.TargetPlatform = core.StringPtr("target_platform=classic")
 				getDeploymentCapabilityOptionsModel.TargetLocation = core.StringPtr("target_location=us-east")
 				getDeploymentCapabilityOptionsModel.HostFlavor = core.StringPtr("host_flavor=multitenant")
+				getDeploymentCapabilityOptionsModel.IncludeHidden = core.BoolPtr(true)
+				getDeploymentCapabilityOptionsModel.IncludeBeta = core.BoolPtr(true)
 				getDeploymentCapabilityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -8628,6 +8641,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				getDeploymentCapabilityOptionsModel.SetTargetPlatform("target_platform=classic")
 				getDeploymentCapabilityOptionsModel.SetTargetLocation("target_location=us-east")
 				getDeploymentCapabilityOptionsModel.SetHostFlavor("host_flavor=multitenant")
+				getDeploymentCapabilityOptionsModel.SetIncludeHidden(true)
+				getDeploymentCapabilityOptionsModel.SetIncludeBeta(true)
 				getDeploymentCapabilityOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getDeploymentCapabilityOptionsModel).ToNot(BeNil())
 				Expect(getDeploymentCapabilityOptionsModel.ID).To(Equal(core.StringPtr("testString")))
@@ -8635,6 +8650,8 @@ var _ = Describe(`CloudDatabasesV5`, func() {
 				Expect(getDeploymentCapabilityOptionsModel.TargetPlatform).To(Equal(core.StringPtr("target_platform=classic")))
 				Expect(getDeploymentCapabilityOptionsModel.TargetLocation).To(Equal(core.StringPtr("target_location=us-east")))
 				Expect(getDeploymentCapabilityOptionsModel.HostFlavor).To(Equal(core.StringPtr("host_flavor=multitenant")))
+				Expect(getDeploymentCapabilityOptionsModel.IncludeHidden).To(Equal(core.BoolPtr(true)))
+				Expect(getDeploymentCapabilityOptionsModel.IncludeBeta).To(Equal(core.BoolPtr(true)))
 				Expect(getDeploymentCapabilityOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetDeploymentInfoOptions successfully`, func() {


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
- Add `hidden` and `beta` versions  when fetching deployment capability versions
- Update upgrade tests to only run if mongo instance (upgrades not available on other db types)
- Formatting fixes

**Fixes:**https://github.ibm.com/compose/App/issues/2466


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
`hidden` and `beta` versions are NOT returned when fetching deployment capability versions 

## What is the new behavior?  
`hidden` and `beta` versions are when fetching deployment capability versions

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Unit and integration test runs

Instance `crn:v1:bluemix:public:databases-for-mongodb:jp-tok:a/40ddc34a953a8c02f10987b59085b60e:8008fe20-e074-4b6e-bbd4-f44ff65eb07f::`

Result
```
make test                                                                                                       
go test `go list ./...`
ok      github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5  (cached)
ok      github.com/IBM/cloud-databases-go-sdk/common    (cached)

make test-int                                                                                                    
go test `go list ./...` -tags=integration
ok      github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5  168.377s
ok      github.com/IBM/cloud-databases-go-sdk/common    (cached)
```